### PR TITLE
Display startup message at dxl_monitor.ino

### DIFF
--- a/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/examples/protocol2.0/dxl_monitor/dxl_monitor.ino
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/examples/protocol2.0/dxl_monitor/dxl_monitor.ino
@@ -21,6 +21,7 @@
 void setup()
 {
   CMD_SERIAL.begin(57600);
+  while(!CMD_SERIAL);
 }
 
 void loop()
@@ -380,6 +381,7 @@ void dxl_monitor_main(void)
     while(1);
   }
 
+  _printf("Be sure to enable Carriage return\n\n");
 
   char    input[128];
   char    cmd[80];


### PR DESCRIPTION
Display startup message when open Serial Monitor and adds orientation on mode (need to enable carriage return).