### PR TITLE
Added a publisher for the standard sensor_msgs::BatteryState message.

### DIFF
--- a/arduino/opencr_arduino/opencr/libraries/turtlebot3/turtlebot3_burger/turtlebot3_core/turtlebot3_core.ino
+++ b/arduino/opencr_arduino/opencr/libraries/turtlebot3/turtlebot3_burger/turtlebot3_core/turtlebot3_core.ino
@@ -49,6 +49,9 @@ ros::Publisher odom_pub("odom", &odom);
 sensor_msgs::JointState joint_states;
 ros::Publisher joint_states_pub("joint_states", &joint_states);
 
+// BatteryState topic
+sensor_msgs::BatteryState battery_state_msg;
+ros::Publisher battery_state_pub("battery_state", &battery_state_msg);
 /*******************************************************************************
 * Transform Broadcaster
 *******************************************************************************/
@@ -143,6 +146,7 @@ void setup()
   nh.advertise(cmd_vel_rc100_pub);
   nh.advertise(odom_pub);
   nh.advertise(joint_states_pub);
+  nh.advertise(battery_state_pub);
   tfbroadcaster.init(nh);
 
   nh.loginfo("Connected to OpenCR board!");
@@ -171,6 +175,13 @@ void setup()
   joint_states.position_length = 2;
   joint_states.velocity_length = 2;
   joint_states.effort_length   = 2;
+
+  // Initialize Battery States
+  battery_state_msg.current         = NAN;
+  battery_state_msg.charge          = NAN;
+  battery_state_msg.capacity        = NAN;
+  battery_state_msg.design_capacity = NAN;
+  battery_state_msg.percentage      = NAN;
 
   prev_update_time = millis();
 
@@ -319,11 +330,14 @@ void publishSensorStateMsg(void)
   sensor_state_msg.stamp = nh.now();
   sensor_state_msg.battery = checkVoltage();
 
+  battery_state_msg.voltage = sensor_state_msg.battery;
+
   dxl_comm_result = motor_driver.readEncoder(sensor_state_msg.left_encoder, sensor_state_msg.right_encoder);
 
   if (dxl_comm_result == true)
   {
     sensor_state_pub.publish(&sensor_state_msg);
+    battery_state_pub.publish(&battery_state_msg);
   }
   else
   {

--- a/arduino/opencr_arduino/opencr/libraries/turtlebot3/turtlebot3_burger/turtlebot3_core/turtlebot3_core_config.h
+++ b/arduino/opencr_arduino/opencr/libraries/turtlebot3/turtlebot3_burger/turtlebot3_core/turtlebot3_core_config.h
@@ -26,6 +26,7 @@
 #include <std_msgs/Int32.h>
 #include <sensor_msgs/Imu.h>
 #include <sensor_msgs/JointState.h>
+#include <sensor_msgs/BatteryState.h>
 #include <geometry_msgs/Vector3.h>
 #include <geometry_msgs/Twist.h>
 #include <tf/tf.h>

--- a/arduino/opencr_arduino/opencr/libraries/turtlebot3/turtlebot3_waffle/turtlebot3_core/turtlebot3_core.ino
+++ b/arduino/opencr_arduino/opencr/libraries/turtlebot3/turtlebot3_waffle/turtlebot3_core/turtlebot3_core.ino
@@ -49,6 +49,9 @@ ros::Publisher odom_pub("odom", &odom);
 sensor_msgs::JointState joint_states;
 ros::Publisher joint_states_pub("joint_states", &joint_states);
 
+// BatteryState topic
+sensor_msgs::BatteryState battery_state_msg;
+ros::Publisher battery_state_pub("battery_state", &battery_state_msg);
 /*******************************************************************************
 * Transform Broadcaster
 *******************************************************************************/
@@ -143,6 +146,7 @@ void setup()
   nh.advertise(cmd_vel_rc100_pub);
   nh.advertise(odom_pub);
   nh.advertise(joint_states_pub);
+  nh.advertise(battery_state_pub);
   tfbroadcaster.init(nh);
 
   nh.loginfo("Connected to OpenCR board!");
@@ -171,6 +175,12 @@ void setup()
   joint_states.position_length = 2;
   joint_states.velocity_length = 2;
   joint_states.effort_length   = 2;
+
+  battery_state_msg.current         = NAN;
+  battery_state_msg.charge          = NAN;
+  battery_state_msg.capacity        = NAN;
+  battery_state_msg.design_capacity = NAN;
+  battery_state_msg.percentage      = NAN;
 
   prev_update_time = millis();
 
@@ -319,11 +329,14 @@ void publishSensorStateMsg(void)
   sensor_state_msg.stamp = nh.now();
   sensor_state_msg.battery = checkVoltage();
 
+  battery_state_msg.voltage = sensor_state_msg.battery;
+
   dxl_comm_result = motor_driver.readEncoder(sensor_state_msg.left_encoder, sensor_state_msg.right_encoder);
 
   if (dxl_comm_result == true)
   {
     sensor_state_pub.publish(&sensor_state_msg);
+    battery_state_pub.publish(&battery_state_msg);
   }
   else
   {

--- a/arduino/opencr_arduino/opencr/libraries/turtlebot3/turtlebot3_waffle/turtlebot3_core/turtlebot3_core_config.h
+++ b/arduino/opencr_arduino/opencr/libraries/turtlebot3/turtlebot3_waffle/turtlebot3_core/turtlebot3_core_config.h
@@ -26,6 +26,7 @@
 #include <std_msgs/Int32.h>
 #include <sensor_msgs/Imu.h>
 #include <sensor_msgs/JointState.h>
+#include <sensor_msgs/BatteryState.h>
 #include <geometry_msgs/Vector3.h>
 #include <geometry_msgs/Twist.h>
 #include <tf/tf.h>


### PR DESCRIPTION
The `NAN` values can be replaced later with the correct stats, I just didn't know them.