### PR TITLE
Fix IMU values

### DIFF
--- a/arduino/opencr_arduino/opencr/libraries/turtlebot3/turtlebot3_burger/turtlebot3_core/turtlebot3_core.ino
+++ b/arduino/opencr_arduino/opencr/libraries/turtlebot3/turtlebot3_burger/turtlebot3_core/turtlebot3_core.ino
@@ -249,9 +249,10 @@ void publishImuMsg(void)
   imu_msg.header.stamp    = nh.now();
   imu_msg.header.frame_id = "imu_link";
 
-  imu_msg.angular_velocity.x = imu.SEN.gyroADC[0];
-  imu_msg.angular_velocity.y = imu.SEN.gyroADC[1];
-  imu_msg.angular_velocity.z = imu.SEN.gyroADC[2];
+  imu_msg.angular_velocity.x = imu.SEN.gyroADC[0] * GYRO_FACTOR;
+  imu_msg.angular_velocity.y = imu.SEN.gyroADC[1] * GYRO_FACTOR;
+  imu_msg.angular_velocity.z = imu.SEN.gyroADC[2] * GYRO_FACTOR;
+
   imu_msg.angular_velocity_covariance[0] = 0.02;
   imu_msg.angular_velocity_covariance[1] = 0;
   imu_msg.angular_velocity_covariance[2] = 0;
@@ -262,9 +263,10 @@ void publishImuMsg(void)
   imu_msg.angular_velocity_covariance[7] = 0;
   imu_msg.angular_velocity_covariance[8] = 0.02;
 
-  imu_msg.linear_acceleration.x = imu.SEN.accADC[0];
-  imu_msg.linear_acceleration.y = imu.SEN.accADC[1];
-  imu_msg.linear_acceleration.z = imu.SEN.accADC[2];
+  imu_msg.linear_acceleration.x = imu.SEN.accADC[0] * ACCEL_FACTOR;
+  imu_msg.linear_acceleration.y = imu.SEN.accADC[1] * ACCEL_FACTOR;
+  imu_msg.linear_acceleration.z = imu.SEN.accADC[2] * ACCEL_FACTOR;
+
   imu_msg.linear_acceleration_covariance[0] = 0.04;
   imu_msg.linear_acceleration_covariance[1] = 0;
   imu_msg.linear_acceleration_covariance[2] = 0;

--- a/arduino/opencr_arduino/opencr/libraries/turtlebot3/turtlebot3_burger/turtlebot3_core/turtlebot3_core_config.h
+++ b/arduino/opencr_arduino/opencr/libraries/turtlebot3/turtlebot3_burger/turtlebot3_core/turtlebot3_core_config.h
@@ -80,6 +80,9 @@
 #define WAIT_SECOND                      1
 #define CHECK_BUTTON_RELEASED            2
 
+#define ACCEL_FACTOR                     -0.000598  // 2.0 * -9.8 / 32768
+#define GYRO_FACTOR                       0.000133  // pi / (131 * 180)
+
 // Callback function prototypes
 void commandVelocityCallback(const geometry_msgs::Twist& cmd_vel_msg);
 

--- a/arduino/opencr_arduino/opencr/libraries/turtlebot3/turtlebot3_waffle/turtlebot3_core/turtlebot3_core.ino
+++ b/arduino/opencr_arduino/opencr/libraries/turtlebot3/turtlebot3_waffle/turtlebot3_core/turtlebot3_core.ino
@@ -249,9 +249,10 @@ void publishImuMsg(void)
   imu_msg.header.stamp    = nh.now();
   imu_msg.header.frame_id = "imu_link";
 
-  imu_msg.angular_velocity.x = imu.SEN.gyroADC[0];
-  imu_msg.angular_velocity.y = imu.SEN.gyroADC[1];
-  imu_msg.angular_velocity.z = imu.SEN.gyroADC[2];
+  imu_msg.angular_velocity.x = imu.SEN.gyroADC[0] * GYRO_FACTOR;
+  imu_msg.angular_velocity.y = imu.SEN.gyroADC[1] * GYRO_FACTOR;
+  imu_msg.angular_velocity.z = imu.SEN.gyroADC[2] * GYRO_FACTOR;
+
   imu_msg.angular_velocity_covariance[0] = 0.02;
   imu_msg.angular_velocity_covariance[1] = 0;
   imu_msg.angular_velocity_covariance[2] = 0;
@@ -262,9 +263,10 @@ void publishImuMsg(void)
   imu_msg.angular_velocity_covariance[7] = 0;
   imu_msg.angular_velocity_covariance[8] = 0.02;
 
-  imu_msg.linear_acceleration.x = imu.SEN.accADC[0];
-  imu_msg.linear_acceleration.y = imu.SEN.accADC[1];
-  imu_msg.linear_acceleration.z = imu.SEN.accADC[2];
+  imu_msg.linear_acceleration.x = imu.SEN.accADC[0] * ACCEL_FACTOR;
+  imu_msg.linear_acceleration.y = imu.SEN.accADC[1] * ACCEL_FACTOR;
+  imu_msg.linear_acceleration.z = imu.SEN.accADC[2] * ACCEL_FACTOR;
+
   imu_msg.linear_acceleration_covariance[0] = 0.04;
   imu_msg.linear_acceleration_covariance[1] = 0;
   imu_msg.linear_acceleration_covariance[2] = 0;

--- a/arduino/opencr_arduino/opencr/libraries/turtlebot3/turtlebot3_waffle/turtlebot3_core/turtlebot3_core_config.h
+++ b/arduino/opencr_arduino/opencr/libraries/turtlebot3/turtlebot3_waffle/turtlebot3_core/turtlebot3_core_config.h
@@ -80,6 +80,9 @@
 #define WAIT_SECOND                      1
 #define CHECK_BUTTON_RELEASED            2
 
+#define ACCEL_FACTOR                     -0.000598  // 2.0 * -9.8 / 32768
+#define GYRO_FACTOR                       0.000133  // pi / (131 * 180)
+
 // Callback function prototypes
 void commandVelocityCallback(const geometry_msgs::Twist& cmd_vel_msg);
 


### PR DESCRIPTION
I'm fixing the IMU values that are being published currently by the `/imu` topic.

According to the document [here](https://www.invensense.com/wp-content/uploads/2015/02/PS-MPU-9250A-01-v1.1.pdf), there is a necessary scale factor that is not being used. If you dig through the code for the IMU, you'll see that they provide the raw ADC values here, which are still raw values.

This is still a work in progress, there's only a PR because I wanted you to know I'm working on it.