### PR TITLE
Fix TF timestamps

### DIFF
--- a/arduino/opencr_arduino/opencr/libraries/turtlebot3/turtlebot3_waffle/turtlebot3_core/turtlebot3_core.ino
+++ b/arduino/opencr_arduino/opencr/libraries/turtlebot3/turtlebot3_waffle/turtlebot3_core/turtlebot3_core.ino
@@ -234,29 +234,29 @@ void loop()
    */
   uint32_t t = millis();
   update_time();
-  if ((millis()-tTime[0]) >= (1000 / CONTROL_MOTOR_SPEED_PERIOD))
+  if ((t-tTime[0]) >= (1000 / CONTROL_MOTOR_SPEED_PERIOD))
   {
     controlMotorSpeed();
-    tTime[0] = millis();
+    tTime[0] = t;
   }
 
-  if ((millis()-tTime[1]) >= (1000 / CMD_VEL_PUBLISH_PERIOD))
+  if ((t-tTime[1]) >= (1000 / CMD_VEL_PUBLISH_PERIOD))
   {
     cmd_vel_rc100_pub.publish(&cmd_vel_rc100_msg);
-    tTime[1] = millis();
+    tTime[1] = t;
   }
 
-  if ((millis()-tTime[2]) >= (1000 / DRIVE_INFORMATION_PUBLISH_PERIOD))
+  if ((t-tTime[2]) >= (1000 / DRIVE_INFORMATION_PUBLISH_PERIOD))
   {
     publishSensorStateMsg();
     publishDriveInformation();
-    tTime[2] = millis();
+    tTime[2] = t;
   }
 
-  if ((millis()-tTime[3]) >= (1000 / IMU_PUBLISH_PERIOD))
+  if ((t-tTime[3]) >= (1000 / IMU_PUBLISH_PERIOD))
   {
     publishImuMsg();
-    tTime[3] = millis();
+    tTime[3] = t;
   }
 
   // Check push button pressed for simple test drive

--- a/arduino/opencr_arduino/opencr/libraries/turtlebot3/turtlebot3_waffle/turtlebot3_core/turtlebot3_core.ino
+++ b/arduino/opencr_arduino/opencr/libraries/turtlebot3/turtlebot3_waffle/turtlebot3_core/turtlebot3_core.ino
@@ -224,6 +224,14 @@ void setup()
 void loop()
 {
   receiveRemoteControlData();
+  /*
+   * the update_time() call below
+   * reduces the amount of calls to
+   * nh.now(), and allows the returned
+   * time to be interpolated on an
+   * as-needed basis with the ros_now()
+   * function.
+   */
   uint32_t t = millis();
   update_time();
   if ((millis()-tTime[0]) >= (1000 / CONTROL_MOTOR_SPEED_PERIOD))
@@ -268,6 +276,8 @@ void loop()
 
   // Call all the callbacks waiting to be called at that point in time
   nh.spinOnce();
+
+  // give the serial link time to process
   delay(10);
 }
 

--- a/arduino/opencr_arduino/opencr/libraries/turtlebot3/turtlebot3_waffle/turtlebot3_core/turtlebot3_core.ino
+++ b/arduino/opencr_arduino/opencr/libraries/turtlebot3/turtlebot3_waffle/turtlebot3_core/turtlebot3_core.ino
@@ -154,18 +154,8 @@ ros::Time add_micros(ros::Time & t, uint32_t _micros)
 *******************************************************************************/
 void update_time()
 {
-  uint32_t n_micros = micros();
-  ros::Time next = nh.now();
-  if (next.sec < current_time.sec) {
-    /*
-     * bad time was received, so we
-     * continue to interpolate the
-     * existing time.
-     */
-    return;
-  }
-  current_time = next;
-  current_offset = n_micros;
+  current_offset = micros();
+  current_time = nh.now();
 }
 
 /*******************************************************************************


### PR DESCRIPTION
This PR increases the accuracy of the timestamps by interpolating from the node handle.

There is an added delay call in the main loop, because, without it, the timestamps were coming in at the
wrong speed.

Finally, the child_frame_id field of the odom topic was missing, so I added it here.

This PR, together with #45, are necessary to map with cartographer (previously, cartographer would crash due to sudden jumps in the timestamps/incorrect timestamps).