### PR TITLE
SPI_HAS_TRANSACTION support

### DIFF
--- a/arduino/opencr_arduino/opencr/libraries/SPI/SPI.cpp
+++ b/arduino/opencr_arduino/opencr/libraries/SPI/SPI.cpp
@@ -139,6 +139,57 @@ void SPIClass::transferFast(void *buf, size_t count) {
   }
 }
 
+
+// Write only functions many used by Adafruit libraries.
+
+void SPIClass::write(uint8_t data) {
+  HAL_SPI_Transmit(_hspi, &data, 1, 0xffff);
+}
+
+void SPIClass::write16(uint16_t data) {
+  uint8_t tBuf[2];
+  tBuf[0] = (uint8_t)(data>>8);
+  tBuf[1] = (uint8_t)data;
+  HAL_SPI_Transmit(_hspi, tBuf, 2, 0xffff);
+}
+
+void SPIClass::write32(uint32_t data) {
+  uint8_t tBuf[4];
+  tBuf[0] = (uint8_t)(data>>24);
+  tBuf[1] = (uint8_t)(data>>16);
+  tBuf[2] = (uint8_t)(data>>8);
+  tBuf[3] = (uint8_t)data;
+  HAL_SPI_Transmit(_hspi, tBuf, 4, 0xffff);
+}
+
+void SPIClass::writeBytes(uint8_t * data, uint32_t size) {
+  HAL_SPI_Transmit(_hspi, data, size, 0xffff);
+}
+
+void SPIClass::writePixels(const void * data, uint32_t size) { //ili9341 compatible
+    // First pass a hack! need to reverse bytes... Use internal buffer.. 
+    uint8_t tBuf[64];
+    uint16_t *pixels = (uint16_t *)data;
+
+    // size is the number of bytes. 
+    while (size) {
+      uint8_t *pb = tBuf;
+
+      uint32_t cb = (size > 64)? 64 : size;
+
+      for (uint32_t i = 0; i < cb; i += 2) {
+        *pb++ = *pixels >> 8;
+        *pb++ = (uint8_t)*pixels;
+        pixels++;
+      }
+      HAL_SPI_Transmit(_hspi, tBuf, cb, 0xffff);
+      size -= cb; 
+
+    }
+}
+
+
+
 void SPIClass::setBitOrder(uint8_t bitOrder) {
   _bitOrder = bitOrder;
   if (bitOrder == 1)

--- a/arduino/opencr_arduino/opencr/libraries/SPI/SPI.h
+++ b/arduino/opencr_arduino/opencr/libraries/SPI/SPI.h
@@ -125,9 +125,19 @@ class SPIClass {
     uint16_t transfer16(uint16_t data);
     void transfer(void *buf, size_t count);
     void transferFast(void *buf, size_t count);
+
+    // Write only functions similar to ESP32 and the like
+    void write(uint8_t data);
+    void write16(uint16_t data);
+    void write32(uint32_t data);
+    void writeBytes(uint8_t * data, uint32_t size);
+    void writePixels(const void * data, uint32_t size);//ili9341 compatible
+
+
     void setBitOrder(uint8_t bitOrder);
     void setClockDivider(uint8_t clockDiv);
     void setDataMode(uint8_t dataMode);
+
 
   private:
     uint32_t _Mode;

--- a/arduino/opencr_arduino/opencr/libraries/SPI/SPI.h
+++ b/arduino/opencr_arduino/opencr/libraries/SPI/SPI.h
@@ -22,6 +22,10 @@
 #include <chip.h>
 #include "variant.h"
 
+// SPI_HAS_TRANSACTION means SPI has beginTransaction(), endTransaction(),
+// usingInterrupt(), and SPISetting(clock, bitOrder, dataMode)
+#define SPI_HAS_TRANSACTION 1
+
 
 #define SPI_CLOCK_DIV4      0x00
 #define SPI_CLOCK_DIV16     0x01
@@ -50,16 +54,44 @@ class SPISettings {
 public:
   SPISettings(uint32_t clock, uint8_t bitOrder, uint8_t dataMode)
   {
-    init_AlwaysInline(clock, bitOrder, dataMode);
+    if (__builtin_constant_p(clock)) {
+      init_Inline(clock, bitOrder, dataMode);
+    } else {
+      init_NotInline(clock, bitOrder, dataMode);
+    }
   }
   SPISettings()
   {
-    init_AlwaysInline(4000000, MSBFIRST, SPI_MODE0);
+    init_Inline(4000000, MSBFIRST, SPI_MODE0);
   }
 private:
-  void init_AlwaysInline(uint32_t clock, uint8_t bitOrder, uint8_t dataMode);
+  void init_NotInline(uint32_t clock, uint8_t bitOrder, uint8_t dataMode) {
+    init_Inline(clock, bitOrder, dataMode);
+  }
 
-  uint8_t clockDiv;
+  void init_Inline(uint32_t clock, uint8_t bitOrder, uint8_t dataMode) 
+    __attribute__((__always_inline__))  {
+      if (clock >= 50000000 / 2) {
+        _clockDiv = SPI_CLOCK_DIV2;
+      } else if (clock >= 50000000 / 4) {
+        _clockDiv = SPI_CLOCK_DIV4;
+      } else if (clock >= 50000000 / 8) {
+        _clockDiv = SPI_CLOCK_DIV8;
+      } else if (clock >= 50000000 / 16) {
+        _clockDiv = SPI_CLOCK_DIV16;
+      } else if (clock >= 50000000 / 32) {
+        _clockDiv = SPI_CLOCK_DIV32;
+      } else if (clock >= 50000000 / 64) {
+        _clockDiv = SPI_CLOCK_DIV64;
+      } else {
+        _clockDiv = SPI_CLOCK_DIV64;
+      }
+
+      _bitOrder = bitOrder;
+      _dataMode = dataMode;
+  }
+
+  uint8_t _clockDiv;
   uint8_t _bitOrder;
   uint8_t _dataMode;
 
@@ -76,9 +108,15 @@ class SPIClass {
 
     void beginTransaction(SPISettings settings)
     {
-      setClockDivider(settings.clockDiv);
-      setBitOrder(settings._bitOrder);
-      setDataMode(settings._dataMode);
+      if (settings._clockDiv != _clockDiv) {
+        setClockDivider(settings._clockDiv);
+      }
+      if (settings._bitOrder != _bitOrder) {
+        setBitOrder(settings._bitOrder);
+      }
+      if (settings._dataMode != _dataMode) {
+        setDataMode(settings._dataMode);
+      }
     }
     void endTransaction(void)
     {
@@ -103,6 +141,11 @@ class SPIClass {
     uint32_t _TIMode;
     uint32_t _CRCCalculation;
     uint32_t _CRCPolynomial;
+    // Keep track of values we set for transactions 
+    uint8_t _clockDiv;
+    uint8_t _bitOrder;
+    uint8_t _dataMode;
+
 
     SPI_HandleTypeDef *_hspi;
     SPI_TypeDef *_spiPort;

--- a/arduino/opencr_arduino/opencr/libraries/SPI/keywords.txt
+++ b/arduino/opencr_arduino/opencr/libraries/SPI/keywords.txt
@@ -13,11 +13,19 @@ SPI	KEYWORD1
 #######################################
 begin			KEYWORD2
 end				KEYWORD2
+beginTransaction	KEYWORD2
+endTransaction	KEYWORD2
 transfer		KEYWORD2
+transfer16		KEYWORD2
+transferFast		KEYWORD2
+write		KEYWORD2
+write16		KEYWORD2
+write32		KEYWORD2
+writeBytes		KEYWORD2
+writePixels		KEYWORD2
 #setBitOrder	KEYWORD2
 setDataMode		KEYWORD2
 setClockDivider	KEYWORD2
-
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
Adding some more support for transactions.

So far mostly reorginize the init code to do more inline support, plus the beginTransaction checks to see if fields are different than current before calling off to change things... Appears to speed things up.

More can be done, but I do have the current Adafruit ILI9341 library working with this.   Can try to issue a PR to Adafruit for the changes in the branch: 
https://github.com/KurtE/Adafruit_ILI9341/tree/OpenCR-support

More can/should be done to for SPI support, like better transfers of buffers and the like, but maybe that can wait for another time, when the support is needed.  