### PR TITLE
Spi enhancements

### DIFF
--- a/arduino/opencr_arduino/opencr/boards.txt
+++ b/arduino/opencr_arduino/opencr/boards.txt
@@ -7,7 +7,7 @@ menu.upload_method=Upload method
 OpenCR.bootloader.tool = dfu_util
 OpenCR.bootloader.file = opencr_boot.bin
 
-OpenCR.name=OpenCR Board
+OpenCR.name=OpenCR Board(develop)
 OpenCR.upload.maximum_size=786432
 
 OpenCR.upload.file_type=bin

--- a/arduino/opencr_arduino/opencr/cores/arduino/Print.cpp
+++ b/arduino/opencr_arduino/opencr/cores/arduino/Print.cpp
@@ -191,7 +191,7 @@ size_t Print::println(const Printable& x)
   return n;
 }
 
-size_t Print::printf(char *fmt, ... )
+size_t Print::printf(const char *fmt, ... )
 {
   char buf[256]; // resulting string limited to 128 chars
   char buf_out[256];

--- a/arduino/opencr_arduino/opencr/cores/arduino/Print.h
+++ b/arduino/opencr_arduino/opencr/cores/arduino/Print.h
@@ -81,7 +81,7 @@ class Print
     size_t println(const Printable&);
     size_t println(void);
 
-    size_t printf(char *fmt, ... );
+    size_t printf(const char *fmt, ... );
 
 };
 

--- a/arduino/opencr_arduino/opencr/libraries/SPI/EventResponder.cpp
+++ b/arduino/opencr_arduino/opencr/libraries/SPI/EventResponder.cpp
@@ -1,0 +1,47 @@
+/* EventResponder - Simple event-based programming for Arduino
+ * Copyright 2017 Paul Stoffregen
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* EventResponder is an experimental API, almost certain to
+ * incompatibly change as it develops.  Please understand any
+ * programs you write now using EventResponder may need to be
+ * updated as EventResponder develops.
+ *
+ * Please post EventResponder post your feedback here:
+ *     https://forum.pjrc.com/threads/44723-Arduino-Events
+ */
+
+#include <Arduino.h>
+#include "EventResponder.h"
+
+
+bool EventResponder::clearEvent()
+{
+	bool ret = false;
+	if (_triggered) {
+		_triggered = false;
+		ret = true;
+	}
+	return ret;
+}
+

--- a/arduino/opencr_arduino/opencr/libraries/SPI/EventResponder.h
+++ b/arduino/opencr_arduino/opencr/libraries/SPI/EventResponder.h
@@ -1,0 +1,161 @@
+/* EventResponder - Simple event-based programming for Arduino
+ * Copyright 2017 Paul Stoffregen
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* EventResponder is an experimental API, almost certain to
+ * incompatibly change as it develops.  Please understand any
+ * programs you write now using EventResponder may need to be
+ * updated as EventResponder develops.
+ *
+ * Please post your EventResponder feedback here:
+ *     https://forum.pjrc.com/threads/44723-Arduino-Events
+ */
+
+// This version was completely reduced to minimums for SPI...
+// By Kurt
+
+#if !defined(EventResponder_h) && defined(__cplusplus)
+#define EventResponder_h
+
+#include <Arduino.h>
+
+/* EventResponder lets you control how your program responds to an event.
+ * Imagine a basketball or football (American soccer) player who gets the
+ * ball.  Usually they will pass to another player who has the best
+ * opportunity to score.  Similarly in Arduino programming, events are
+ * often triggered within interrupts or other timing sensitive code.
+ * EventResponder can call your function a short time later, giving you
+ * the ability to use Arduino functions and libraries which would not
+ * be safe to use from an interrupt.  However, some situations do call
+ * for the most immediate response, even if doing so is more difficult.
+ * EventResponder lets you choose how your function will be called,
+ * without editing the timers or libraries which trigger the events.
+ *
+ * Event handling functions called by EventResponder should complete
+ * their work quickly.  Avoid delays or operations which may take
+ * substantial time.  While your function runs, no other event functions
+ * (attached the same way) are able to run.
+ *
+ * If your EventResponder is triggered more than once before your
+ * function can run, only the last trigger is used.  Prior triggering,
+ * including the status integer and data pointer, are overwritten and
+ * your function is called only one time, based on the last trigger
+ * event.
+ */
+
+class EventResponder;
+typedef EventResponder& EventResponderRef;
+typedef void (*EventResponderFunction)(EventResponderRef);
+class EventResponder
+{
+public:
+	EventResponder() {
+		_status = 0;
+		_function = NULL;
+		_data = NULL;
+		_context = NULL;
+		_type = EventTypeDetached;
+		_triggered = false;
+	}
+	~EventResponder() {
+		detach();
+	}
+	enum EventType { // these are not meant for public consumption...
+		EventTypeDetached = 0, // no function is called
+		EventTypeImmediate    // function is called immediately
+	};
+
+	// Attach a function to be called from yield().  This should be the
+	// default way to use EventResponder.  Calls from yield() allow use
+	// of Arduino libraries, String, Serial, etc.
+	void attach(EventResponderFunction function, uint8_t priority=128) {
+		UNUSED(priority);
+		_function = function;
+		_type = EventTypeImmediate;
+	}
+
+	// Attach a function to be called immediately.  This provides the
+	// fastest possible response, but your function must be carefully
+	// designed.
+	void attachImmediate(EventResponderFunction function) {
+		_function = function;
+		_type = EventTypeImmediate;
+	}
+
+	// Do not call any function.  The user's program must occasionally check
+	// whether the event has occurred, or use one of the wait functions.
+	void detach() {
+	}
+
+	// Trigger the event.  An optional status code and data may be provided.
+	// The code triggering the event does NOT control which of the above
+	// response methods will be used.
+	virtual void triggerEvent(int status=0, void *data=NULL) {
+		_status = status;
+		_data = data;
+		if (_type == EventTypeImmediate) {
+			(*_function)(*this);
+		} else {
+			//triggerEventNotImmediate();
+		}
+	}
+	// Clear an event which has been triggered, but has not yet caused a
+	// function to be called.
+	bool clearEvent();
+
+	// Get the event's status code.  Typically this will indicate if the event was
+	// triggered due to successful completion, or how much data was successfully
+	// processed (positive numbers) or an error (negative numbers).  The
+	// exact meaning of this status code depends on the code or library which
+	// triggers the event.
+	int getStatus() { return _status; }
+
+	// Get the optional data pointer associated with the event.  Often this
+	// will be NULL, or will be the object instance which triggered the event.
+	// Some libraries may use this to pass data associated with the event.
+	void * getData() { return _data; }
+
+	// An optional "context" may be associated with each EventResponder.
+	// When more than one EventResponder has the same function attached, these
+	// may be used to allow the function to obtain extra information needed
+	// depending on which EventResponder called it.
+	void setContext(void *context) { _context = context; }
+	void * getContext() { return _context; }
+
+	// Wait for event(s) to occur.  These are most likely to be useful when
+	// used with a scheduler or RTOS.
+	bool waitForEvent(EventResponderRef event, int timeout);
+	EventResponder * waitForEvent(EventResponder *list, int listsize, int timeout);
+
+	operator bool() { return _triggered; }
+protected:
+	int _status;
+	EventResponderFunction _function;
+	void *_data;
+	void *_context;
+	EventType _type;
+	bool _triggered;
+private:
+};
+
+#endif

--- a/arduino/opencr_arduino/opencr/libraries/SPI/SPI.cpp
+++ b/arduino/opencr_arduino/opencr/libraries/SPI/SPI.cpp
@@ -22,18 +22,21 @@
 
 
 /* Create an SPIClass instance */
-SPIClass SPI    (SPI2);
-SPIClass SPI_IMU(SPI1);
+SPIClass SPI    (SPI2, 50000000);
+SPIClass SPI_IMU(SPI1, 100000000);
+SPIClass SPI_EXT(SPI4, 100000000);
 
 
-
-SPIClass::SPIClass(SPI_TypeDef *spiPort) {
+SPIClass::SPIClass(SPI_TypeDef *spiPort, uint32_t spi_clock) {
   _spiPort = spiPort;
 
   if(spiPort == SPI1)
     _hspi = &hspi1;
-  if(spiPort == SPI2)
+  else if(spiPort == SPI2)
     _hspi = &hspi2;
+  else if(spiPort == SPI4)
+    _hspi = &hspi4;
+  _spi_clock = spi_clock;
 }
 
 /**
@@ -51,6 +54,10 @@ SPIClass::SPIClass(uint8_t spiPort){
       _spiPort = SPI2;
       _hspi = &hspi2;
     break;
+    case 4:
+      _spiPort = SPI4;
+      _hspi = &hspi4;
+    break;
   }
 }
 
@@ -66,10 +73,11 @@ void SPIClass::beginFast(void) {
 
 void SPIClass::init(void){
   // Keep track of transaction logical values.
-  _clockDiv = SPI_CLOCK_DIV16;
+  //_clockDiv = SPI_CLOCK_DIV16;
   _bitOrder = MSBFIRST;
   _dataMode = SPI_MODE0;
-
+  _dma_state = DMA_NOTINITIALIZED;
+  _dma_event_responder   = NULL;
   _hspi->Instance               = _spiPort;
   _hspi->Init.Mode              = SPI_MODE_MASTER;
   _hspi->Init.Direction         = SPI_DIRECTION_2LINES;
@@ -107,23 +115,26 @@ uint16_t SPIClass::transfer16(uint16_t data) {
 }
 
 
-void SPIClass::writeFast(void *buf, size_t count) {
-  uint32_t t_time;
-  
-  drv_spi_start_dma_tx(_hspi, (uint8_t *)buf, count);
+void SPIClass::transfer(const void * buf, void * retbuf, size_t count) {
+  if ((count == 0) || ((buf == NULL) && (retbuf == NULL))) return;    // nothing to do
 
-  t_time = millis();
-
-  while(1)
+//  bool dma_enabled = drv_spi_dma_enabled(_hspi);
+  HAL_StatusTypeDef status;
+  if (retbuf == NULL) { 
+    // write only transfer
+    status = HAL_SPI_Transmit(_hspi, (uint8_t *)buf, count, 0xffff);
+  } else if (buf == NULL) {
+    // Read only buffer
+    status = HAL_SPI_Receive(_hspi, (uint8_t*)retbuf, count, 0xffff);
+  } else {
+    // standard Read/write buffer transfer
+    // start off without DMA support
+    status = HAL_SPI_TransmitReceive(_hspi, (uint8_t *)buf, (uint8_t*)retbuf, count, 0xffff);
+  }
+  if (status != HAL_OK) 
   {
-    if(drv_spi_is_dma_tx_done(_hspi))
-    {
-      break;
-    }
-    if((millis()-t_time) > 1000)
-    {
-      break;
-    }
+    Serial.print("transfer status: ");
+    Serial.println((int)status, DEC);
   }
 }
 
@@ -189,7 +200,7 @@ void SPIClass::setBitOrder(uint8_t bitOrder) {
 
 
 void SPIClass::setClockDivider(uint8_t clockDiv) {
-  _clockDiv = clockDiv;
+  _clock = 0;   // clear out so we will set in setClock
   switch(clockDiv){
     case SPI_CLOCK_DIV2:
       _hspi->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_2;
@@ -215,6 +226,28 @@ void SPIClass::setClockDivider(uint8_t clockDiv) {
     case SPI_CLOCK_DIV256:
       _hspi->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_256;
     break;
+  }
+  HAL_SPI_Init(_hspi);
+}
+
+void SPIClass::setClock(uint32_t clock) {
+  _clock = clock; // remember our new clock  
+  if (clock >= _spi_clock / 2) {
+    _hspi->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_2;
+  } else if (clock >= _spi_clock / 4) {
+    _hspi->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_4;
+  } else if (clock >= _spi_clock / 8) {
+    _hspi->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_8;
+  } else if (clock >= _spi_clock / 16) {
+    _hspi->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_16;
+  } else if (clock >= _spi_clock / 32) {
+    _hspi->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_32;
+  } else if (clock >= _spi_clock / 64) {
+    _hspi->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_64;
+  } else if (clock >= _spi_clock / 128) {
+    _hspi->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_128;
+  } else {
+    _hspi->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_128;  // Our slowest mode
   }
   HAL_SPI_Init(_hspi);
 }
@@ -252,4 +285,56 @@ void SPIClass::setDataMode(uint8_t dataMode){
       HAL_SPI_Init(_hspi);
       break;
   }
+}
+//=========================================================================
+// Main Async Transfer function
+//=========================================================================
+
+bool SPIClass::transfer(const void *buf, void *retbuf, size_t count, EventResponderRef event_responder) {
+//    Serial.println("Transfer with Event Call"); Serial.flush();
+  if (_dma_state == DMA_ACTIVE)
+    return false; // already active
+  else if (_dma_state == DMA_NOTINITIALIZED)
+  {
+//    Serial.println("Before SPI enable DMA"); Serial.flush();
+    drv_spi_enable_dma(_hspi);
+    _dma_state = DMA_IDLE;
+  }
+//  Serial.println("Before Clear event");  Serial.flush();
+  event_responder.clearEvent(); // Make sure it is not set yet
+  if (count < 2) {
+    // Use non-async version to simplify cases...
+    transfer(buf, retbuf, count);
+    event_responder.triggerEvent();
+    return true;
+  }
+
+  if ((count == 0) || ((buf == NULL) && (retbuf == NULL))) return false;    // nothing to do
+
+  _dma_event_responder = &event_responder;  // remember the event object
+  //bool dma_enabled = drv_spi_dma_enabled(_hspi);
+  // new version handles where buf or retbuf are null
+  drv_spi_start_dma_txrx(_hspi, (uint8_t *)buf, (uint8_t *)retbuf, count, &dmaCallback);
+  _dma_state = DMA_ACTIVE;
+  return true;
+}
+
+void SPIClass::dmaCallback(SPI_HandleTypeDef* hspi)
+{
+  // Static function call from our DMA DRV code
+  if (hspi == &hspi1) SPI_IMU.processDMACallback();
+  else if (hspi == &hspi2) SPI.processDMACallback();
+  else if (hspi == &hspi4) SPI_EXT.processDMACallback();
+
+}
+
+void SPIClass::processDMACallback()
+{
+  // We have been called back, that the DMA completed
+  if (_dma_event_responder)
+  {
+    _dma_state = DMA_COMPETED;   // set back to 1 in case our call wants to start up dma again
+    _dma_event_responder->triggerEvent();
+  }
+
 }

--- a/arduino/opencr_arduino/opencr/variants/OpenCR/chip.h
+++ b/arduino/opencr_arduino/opencr/variants/OpenCR/chip.h
@@ -13,7 +13,7 @@
 
 #define USE_SPI1
 #define USE_SPI2
-
+#define USE_SPI4
 
 #define BOARD_NR_I2C  2
 #define HAL_I2C1      I2C1

--- a/arduino/opencr_arduino/opencr/variants/OpenCR/hw/driver/drv_spi.c
+++ b/arduino/opencr_arduino/opencr/variants/OpenCR/hw/driver/drv_spi.c
@@ -9,30 +9,44 @@
 #include "variant.h"
 
 
-#define SPI_MAX_CH              2
+#define SPI_MAX_CH              3
 #define SPI_TX_DMA_MAX_LENGTH   0xEFFF
 
 
 
 typedef struct
 {
-  bool use;
-  bool init;
-  bool tx_done;
+  bool    use;
+  bool    init;
+  uint32_t length_left;
+  bool    transfer_done;
+  // TX state variables
   uint8_t *p_tx_buf;
-  uint8_t *p_tx_buf_next;
-  uint32_t tx_length_next;
+  // RX state variables - Maybe some can be combined with TX
+  uint8_t *p_rx_buf;
+  DrvSPIDMACallback dma_callback;    // Optional function to call at DMA completion
 } spi_dma_t;
 
 
 SPI_HandleTypeDef hspi1;
 SPI_HandleTypeDef hspi2;
+SPI_HandleTypeDef hspi4;
 
 static DMA_HandleTypeDef hdma2_tx;
+static DMA_HandleTypeDef hdma2_rx;
+static DMA_HandleTypeDef hdma4_tx;
+static DMA_HandleTypeDef hdma4_rx;
 
 volatile spi_dma_t spi_dma[SPI_MAX_CH];
 
 
+inline volatile spi_dma_t *drv_map_haspi_to_spi_dma(SPI_HandleTypeDef* hspi) 
+{
+  if (hspi->Instance == SPI1) return &spi_dma[0];
+  if (hspi->Instance == SPI2) return &spi_dma[1];
+  if (hspi->Instance == SPI4) return &spi_dma[2];
+  return NULL;
+}
 
 
 
@@ -70,15 +84,30 @@ int drv_spi_init()
   hspi2.Init.CRCPolynomial      = 10;
   //HAL_SPI_Init(&hspi2);
 
+  hspi4.Instance                = SPI4;
+  hspi4.Init.Mode               = SPI_MODE_MASTER;
+  hspi4.Init.Direction          = SPI_DIRECTION_2LINES;
+  hspi4.Init.DataSize           = SPI_DATASIZE_8BIT;
+  hspi4.Init.CLKPolarity        = SPI_POLARITY_LOW;
+  hspi4.Init.CLKPhase           = SPI_PHASE_1EDGE;
+  hspi4.Init.NSS                = SPI_NSS_SOFT;
+  hspi4.Init.BaudRatePrescaler  = SPI_BAUDRATEPRESCALER_16;
+  hspi4.Init.FirstBit           = SPI_FIRSTBIT_MSB;
+  hspi4.Init.TIMode             = SPI_TIMODE_DISABLE;
+  hspi4.Init.CRCCalculation     = SPI_CRCCALCULATION_DISABLE;
+  hspi4.Init.CRCPolynomial      = 10;
+  //HAL_SPI_Init(&hspi4);
+
 
   for(i=0; i<SPI_MAX_CH; i++)
   {
     spi_dma[i].p_tx_buf         = NULL;
-    spi_dma[i].p_tx_buf_next    = NULL;
+    spi_dma[i].p_rx_buf         = NULL;
     spi_dma[i].use              = false;
     spi_dma[i].init             = false;
-    spi_dma[i].tx_done          = false;
-    spi_dma[i].tx_length_next   = 0;
+    spi_dma[i].transfer_done    = false;
+    spi_dma[i].length_left      = 0;
+    spi_dma[i].dma_callback     = NULL;
   }
 
   return 0;
@@ -90,93 +119,87 @@ void drv_spi_enable_dma(SPI_HandleTypeDef* hspi)
   if(hspi->Instance==SPI1)
   {
   }
-  if(hspi->Instance==SPI2)
+  else if(hspi->Instance==SPI2)
   {
     spi_dma[1].use = true;
   }
+  else if(hspi->Instance==SPI4)
+  {
+    spi_dma[2].use = true;
+  }
 }
 
+bool drv_spi_dma_enabled(SPI_HandleTypeDef* hspi) 
+{
+ volatile spi_dma_t *pspi_dma = drv_map_haspi_to_spi_dma(hspi);
+ return pspi_dma->use;
+}
+
+//=================================================================
+// Support for DMA TX Only
+//=================================================================
 
 uint8_t drv_spi_is_dma_tx_done(SPI_HandleTypeDef* hspi)
 {
-  if(hspi->Instance==SPI1)
-  {
-    if(spi_dma[0].use != true) return true;
-
-    return spi_dma[0].tx_done;
-  }
-  if(hspi->Instance==SPI2)
-  {
-    if(spi_dma[1].use != true) return true;
-
-    return spi_dma[1].tx_done;
-  }
-
-  return true;
+  volatile spi_dma_t *pspi_dma = drv_map_haspi_to_spi_dma(hspi);
+  if (!pspi_dma || (pspi_dma->use != true)) return true;  
+  return pspi_dma->transfer_done;
 }
 
 
-void drv_spi_start_dma_tx(SPI_HandleTypeDef* hspi, uint8_t *p_buf, uint32_t length)
+void drv_spi_start_dma_tx(SPI_HandleTypeDef* hspi, uint8_t *p_buf, uint32_t length, DrvSPIDMACallback dma_callback)
 {
-  if(hspi->Instance==SPI1)
-  {
-  }
-  if(hspi->Instance==SPI2)
-  {
-    if(spi_dma[1].use != true) return;
+ volatile spi_dma_t *pspi_dma = drv_map_haspi_to_spi_dma(hspi);
 
-    if(length > SPI_TX_DMA_MAX_LENGTH)
-    {
-      spi_dma[1].tx_done       = false;
-      spi_dma[1].tx_length_next= length - SPI_TX_DMA_MAX_LENGTH;
-      spi_dma[1].p_tx_buf      =  p_buf;
-      spi_dma[1].p_tx_buf_next = &p_buf[SPI_TX_DMA_MAX_LENGTH];
+  if ((pspi_dma == NULL) || (pspi_dma->use != true)) return ;
 
-      HAL_SPI_Transmit_DMA(hspi, spi_dma[1].p_tx_buf, SPI_TX_DMA_MAX_LENGTH);
-    }
-    else
-    {
-      spi_dma[1].tx_done       = false;
-      spi_dma[1].tx_length_next= 0;
-      spi_dma[1].p_tx_buf      = p_buf;
-      spi_dma[1].p_tx_buf_next = NULL;
+  pspi_dma->transfer_done       = false;
+  pspi_dma->length_left     = length;
+  pspi_dma->p_tx_buf        =  p_buf;
+  pspi_dma->p_rx_buf        = NULL;   // this will funnel through txrx is set to NULL
+  pspi_dma->transfer_done   = false;
+  pspi_dma->dma_callback    = dma_callback;
+  
+  if(length > SPI_TX_DMA_MAX_LENGTH)
+    length = SPI_TX_DMA_MAX_LENGTH;
 
-      HAL_SPI_Transmit_DMA(hspi, spi_dma[1].p_tx_buf, length);
-    }
-  }
+  pspi_dma->length_left -= length;
+
+  HAL_SPI_TransmitReceive_DMA(hspi, pspi_dma->p_tx_buf, NULL, length);
+  //HAL_SPI_Transmit_DMA(hspi, pspi_dma->p_tx_buf, SPI_TX_DMA_MAX_LENGTH);
 }
 
 void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef *hspi)
 {
-  volatile uint16_t length;
-
-
-  if(hspi->Instance==SPI2)
+//  HAL_GPIO_WritePin(GPIOC, GPIO_PIN_7, 1);    // digitalWrite(0, HIGH);
+  volatile spi_dma_t *pspi_dma = drv_map_haspi_to_spi_dma(hspi);
+  volatile uint32_t length;
+  if (pspi_dma && (hspi->Instance != SPI1))
   {
-    if(spi_dma[1].tx_length_next > 0)
-    {
-      spi_dma[1].p_tx_buf = spi_dma[1].p_tx_buf_next;
+    length = pspi_dma->length_left;
 
-      if(spi_dma[1].tx_length_next > SPI_TX_DMA_MAX_LENGTH)
+    if(length > 0)
+    {
+      pspi_dma->p_tx_buf += SPI_TX_DMA_MAX_LENGTH;
+      if (length > SPI_TX_DMA_MAX_LENGTH)
       {
         length = SPI_TX_DMA_MAX_LENGTH;
-        spi_dma[1].tx_length_next = spi_dma[1].tx_length_next - SPI_TX_DMA_MAX_LENGTH;
-        spi_dma[1].p_tx_buf_next = &spi_dma[1].p_tx_buf[SPI_TX_DMA_MAX_LENGTH];
       }
-      else
-      {
-        length = spi_dma[1].tx_length_next;
-        spi_dma[1].tx_length_next = 0;
-        spi_dma[1].p_tx_buf_next = NULL;
-      }
-      HAL_SPI_Transmit_DMA(hspi, spi_dma[1].p_tx_buf, length);
+      pspi_dma->length_left -= length;
+      //HAL_SPI_Transmit_DMA(hspi, pspi_dma->p_tx_buf, length);
+      HAL_SPI_TransmitReceive_DMA(hspi, pspi_dma->p_tx_buf, NULL, length);
     }
     else
     {
-      spi_dma[1].tx_done = true;
+      pspi_dma->transfer_done = true;
+      if (pspi_dma->dma_callback) 
+      {
+        (*pspi_dma->dma_callback)(hspi);
+      }
     }
 
   }
+//  HAL_GPIO_WritePin(GPIOC, GPIO_PIN_7, 0);    // digitalWrite(0, HIGH);
 }
 
 
@@ -187,12 +210,108 @@ void DMA1_Stream4_IRQHandler(void)
   HAL_DMA_IRQHandler(hspi2.hdmatx);
 }
 
+void DMA2_Stream1_IRQHandler(void)
+{
+  HAL_DMA_IRQHandler(hspi4.hdmatx);
+}
 
+
+// SPIx_DMA_RX_IRQHandler(void)
+//
+void DMA1_Stream3_IRQHandler(void)
+{
+  HAL_DMA_IRQHandler(hspi2.hdmarx);
+}
+
+void DMA2_Stream0_IRQHandler(void)
+{
+  HAL_DMA_IRQHandler(hspi4.hdmarx);
+}
+
+//=================================================================
+// Support for DMA Transfer
+//=================================================================
+uint8_t drv_spi_is_dma_txrx_done(SPI_HandleTypeDef* hspi)
+{
+  volatile spi_dma_t *pspi_dma = drv_map_haspi_to_spi_dma(hspi);
+  if (!pspi_dma || (pspi_dma->use != true)) return true;  
+  return pspi_dma->transfer_done;
+}
+
+
+void drv_spi_start_dma_txrx(SPI_HandleTypeDef* hspi, uint8_t *p_buf, uint8_t *p_rxbuf, uint32_t length, DrvSPIDMACallback dma_callback)
+{
+ volatile spi_dma_t *pspi_dma = drv_map_haspi_to_spi_dma(hspi);
+
+  if ((pspi_dma == NULL) || (pspi_dma->use != true)) return ;
+
+  // Assume TX and RX max length are the same
+  pspi_dma->p_tx_buf        =  p_buf;
+  pspi_dma->p_rx_buf        =  p_rxbuf;
+  pspi_dma->length_left     = length;
+  pspi_dma->transfer_done   = false;
+  pspi_dma->dma_callback    = dma_callback;
+
+
+  if (length > SPI_TX_DMA_MAX_LENGTH) 
+  {
+    length = SPI_TX_DMA_MAX_LENGTH;
+  }
+  pspi_dma->length_left -= length;
+  HAL_SPI_TransmitReceive_DMA(hspi, pspi_dma->p_tx_buf, pspi_dma->p_rx_buf, length);
+}
+
+void HAL_SPI_TxRxCpltCallback(SPI_HandleTypeDef *hspi)
+{
+  volatile spi_dma_t *pspi_dma = drv_map_haspi_to_spi_dma(hspi);
+  //HAL_GPIO_WritePin(GPIOC, GPIO_PIN_7, 1);    // digitalWrite(0, HIGH);
+  if (pspi_dma && (hspi->Instance != SPI1))
+  {
+    volatile uint32_t length = pspi_dma->length_left;
+    if(length > 0)
+    {
+      if (pspi_dma->p_rx_buf)
+      {
+        pspi_dma->p_rx_buf += SPI_TX_DMA_MAX_LENGTH;
+      }
+      if (pspi_dma->p_tx_buf)
+      {
+        pspi_dma->p_tx_buf += SPI_TX_DMA_MAX_LENGTH;
+      }
+
+      if (length > SPI_TX_DMA_MAX_LENGTH)
+      {
+        length = SPI_TX_DMA_MAX_LENGTH;
+      }
+      pspi_dma->length_left -= length;
+      //vcp_printf("TxRxCB: %x %x %d\n", (uint32_t)pspi_dma->p_tx_buf, (uint32_t)pspi_dma->p_rx_buf, length);
+      HAL_SPI_TransmitReceive_DMA(hspi, pspi_dma->p_tx_buf, pspi_dma->p_rx_buf, length);
+    }
+    else
+    {
+      pspi_dma->transfer_done = true;
+      if (pspi_dma->dma_callback) 
+      {
+        (*pspi_dma->dma_callback)(hspi);
+      }
+    }
+
+  }
+  //HAL_GPIO_WritePin(GPIOC, GPIO_PIN_7, 0);    // digitalWrite(0, LOW);
+}
+
+
+
+//=================================================================
+// Init HAL SPI
+//=================================================================
 void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi)
 {
 
   GPIO_InitTypeDef GPIO_InitStruct;
 
+
+  // BUGBUG:: Would be nice to more table drive this!
 
   if(hspi->Instance==SPI1)
   {
@@ -269,6 +388,111 @@ void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi)
 
       HAL_NVIC_SetPriority(DMA1_Stream4_IRQn, 1, 1);
       HAL_NVIC_EnableIRQ(DMA1_Stream4_IRQn);
+
+      /* Configure the DMA handler for receive process */
+      hdma2_rx.Instance                 = DMA1_Stream3;
+      hdma2_rx.Init.Channel             = DMA_CHANNEL_0;
+      hdma2_rx.Init.FIFOMode            = DMA_FIFOMODE_DISABLE;
+      hdma2_rx.Init.FIFOThreshold       = DMA_FIFO_THRESHOLD_FULL;
+      hdma2_rx.Init.MemBurst            = DMA_MBURST_INC4;
+      hdma2_rx.Init.PeriphBurst         = DMA_PBURST_INC4;
+      hdma2_rx.Init.Direction           = DMA_PERIPH_TO_MEMORY;
+      hdma2_rx.Init.PeriphInc           = DMA_PINC_DISABLE;
+      hdma2_rx.Init.MemInc              = DMA_MINC_ENABLE;
+      hdma2_rx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
+      hdma2_rx.Init.MemDataAlignment    = DMA_MDATAALIGN_BYTE;
+      hdma2_rx.Init.Mode                = DMA_NORMAL;
+      hdma2_rx.Init.Priority            = DMA_PRIORITY_LOW;
+
+      HAL_DMA_Init(&hdma2_rx);
+
+      /* Associate the initialized DMA handle to the the SPI handle */
+      __HAL_LINKDMA(hspi, hdmarx, hdma2_rx);
+
+
+      HAL_NVIC_SetPriority(DMA1_Stream3_IRQn, 1, 1);
+      HAL_NVIC_EnableIRQ(DMA1_Stream3_IRQn);
+    }
+  }
+
+  if(hspi->Instance==SPI4)
+  {
+    __HAL_RCC_SPI4_CLK_ENABLE();
+    // SCK - Arduino pin 58
+    GPIO_InitStruct.Pin       = GPIO_PIN_12;
+    GPIO_InitStruct.Mode      = GPIO_MODE_AF_PP;
+    GPIO_InitStruct.Pull      = GPIO_PULLUP;
+    GPIO_InitStruct.Speed     = GPIO_SPEED_HIGH;
+    GPIO_InitStruct.Alternate = GPIO_AF5_SPI4;
+    HAL_GPIO_Init(GPIOE, &GPIO_InitStruct);
+
+    /* SPI MISO GPIO pin configuration  59 */
+    GPIO_InitStruct.Pin       = GPIO_PIN_13;
+    GPIO_InitStruct.Alternate = GPIO_AF5_SPI4;
+    HAL_GPIO_Init(GPIOE, &GPIO_InitStruct);
+
+    /* SPI MOSI GPIO pin configuration  60 */
+    GPIO_InitStruct.Pin       = GPIO_PIN_14;
+    GPIO_InitStruct.Alternate = GPIO_AF5_SPI4;
+    HAL_GPIO_Init(GPIOE, &GPIO_InitStruct);
+
+
+    if(spi_dma[2].use == true && spi_dma[2].init == false)
+    {
+      spi_dma[2].init = true;
+
+      bsp_mpu_config();
+
+      __HAL_RCC_DMA2_CLK_ENABLE();
+
+      /* Configure the DMA handler for Transmission process */
+      hdma4_tx.Instance                 = DMA2_Stream1;
+      hdma4_tx.Init.Channel             = DMA_CHANNEL_4;
+      hdma4_tx.Init.FIFOMode            = DMA_FIFOMODE_DISABLE;
+      hdma4_tx.Init.FIFOThreshold       = DMA_FIFO_THRESHOLD_FULL;
+      hdma4_tx.Init.MemBurst            = DMA_MBURST_INC4;
+      hdma4_tx.Init.PeriphBurst         = DMA_PBURST_INC4;
+      hdma4_tx.Init.Direction           = DMA_MEMORY_TO_PERIPH;
+      hdma4_tx.Init.PeriphInc           = DMA_PINC_DISABLE;
+      hdma4_tx.Init.MemInc              = DMA_MINC_ENABLE;
+      hdma4_tx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
+      hdma4_tx.Init.MemDataAlignment    = DMA_MDATAALIGN_BYTE;
+      hdma4_tx.Init.Mode                = DMA_NORMAL;
+      hdma4_tx.Init.Priority            = DMA_PRIORITY_LOW;
+
+      HAL_DMA_Init(&hdma4_tx);
+
+      /* Associate the initialized DMA handle to the the SPI handle */
+      __HAL_LINKDMA(hspi, hdmatx, hdma4_tx);
+
+
+      HAL_NVIC_SetPriority(DMA2_Stream1_IRQn, 1, 1);
+      HAL_NVIC_EnableIRQ(DMA2_Stream1_IRQn);
+
+      /* Configure the DMA handler for receive process */
+      hdma4_rx.Instance                 = DMA2_Stream0;
+      hdma4_rx.Init.Channel             = DMA_CHANNEL_4;
+      hdma4_rx.Init.FIFOMode            = DMA_FIFOMODE_DISABLE;
+      hdma4_rx.Init.FIFOThreshold       = DMA_FIFO_THRESHOLD_FULL;
+      hdma4_rx.Init.MemBurst            = DMA_MBURST_INC4;
+      hdma4_rx.Init.PeriphBurst         = DMA_PBURST_INC4;
+      hdma4_rx.Init.Direction           = DMA_PERIPH_TO_MEMORY;
+      hdma4_rx.Init.PeriphInc           = DMA_PINC_DISABLE;
+      hdma4_rx.Init.MemInc              = DMA_MINC_ENABLE;
+      hdma4_rx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
+      hdma4_rx.Init.MemDataAlignment    = DMA_MDATAALIGN_BYTE;
+      hdma4_rx.Init.Mode                = DMA_NORMAL;
+      hdma4_rx.Init.Priority            = DMA_PRIORITY_LOW;
+
+      HAL_DMA_Init(&hdma4_rx);
+
+      /* Associate the initialized DMA handle to the the SPI handle */
+      __HAL_LINKDMA(hspi, hdmarx, hdma4_rx);
+
+
+      HAL_NVIC_SetPriority(DMA2_Stream0_IRQn, 1, 1);
+      HAL_NVIC_EnableIRQ(DMA2_Stream0_IRQn);
+
     }
   }
 
@@ -292,7 +516,7 @@ void HAL_SPI_MspDeInit(SPI_HandleTypeDef* hspi)
     HAL_NVIC_DisableIRQ(SPI1_IRQn);
   }
 
-  if(hspi->Instance==SPI2)
+  else if(hspi->Instance==SPI2)
   {
     __HAL_RCC_SPI2_FORCE_RESET();
     __HAL_RCC_SPI2_RELEASE_RESET();
@@ -306,5 +530,18 @@ void HAL_SPI_MspDeInit(SPI_HandleTypeDef* hspi)
     /* Peripheral interrupt Deinit*/
     HAL_NVIC_DisableIRQ(SPI2_IRQn);
   }
+  else if(hspi->Instance==SPI4)
+  {
+    __HAL_RCC_SPI4_FORCE_RESET();
+    __HAL_RCC_SPI4_RELEASE_RESET();
+    __HAL_RCC_SPI4_CLK_DISABLE();
 
+
+    HAL_GPIO_DeInit(GPIOE, GPIO_PIN_12);
+    HAL_GPIO_DeInit(GPIOE, GPIO_PIN_13);
+    HAL_GPIO_DeInit(GPIOE, GPIO_PIN_14);
+
+    /* Peripheral interrupt Deinit*/
+    HAL_NVIC_DisableIRQ(SPI4_IRQn);
+  }
 }

--- a/arduino/opencr_arduino/opencr/variants/OpenCR/hw/driver/drv_spi.h
+++ b/arduino/opencr_arduino/opencr/variants/OpenCR/hw/driver/drv_spi.h
@@ -20,14 +20,17 @@
 
 
 
-
+typedef void (*DrvSPIDMACallback)(SPI_HandleTypeDef* hspi);
 
 
 
 int     drv_spi_init();
 void    drv_spi_enable_dma(SPI_HandleTypeDef* hspi);
+bool    drv_spi_dma_enabled(SPI_HandleTypeDef* hspi);
 uint8_t drv_spi_is_dma_tx_done(SPI_HandleTypeDef* hspi);
-void    drv_spi_start_dma_tx(SPI_HandleTypeDef* hspi, uint8_t *p_buf, uint32_t length);
+void    drv_spi_start_dma_tx(SPI_HandleTypeDef* hspi, uint8_t *p_buf, uint32_t length, DrvSPIDMACallback dma_callback);
+void    drv_spi_start_dma_txrx(SPI_HandleTypeDef* hspi, uint8_t *p_buf, uint8_t *p_rxbuf, uint32_t length, 
+			DrvSPIDMACallback dma_callback);
 
 #ifdef __cplusplus
 }

--- a/arduino/opencr_arduino/opencr/variants/OpenCR/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_spi.h
+++ b/arduino/opencr_arduino/opencr/variants/OpenCR/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_spi.h
@@ -138,15 +138,15 @@ typedef struct __SPI_HandleTypeDef
 
   uint8_t                 *pTxBuffPtr;    /* Pointer to SPI Tx transfer Buffer */
 
-  uint16_t                TxXferSize;     /* SPI Tx Transfer size */
+  uint32_t                TxXferSize;     /* SPI Tx Transfer size */
 
-  uint16_t                TxXferCount;    /* SPI Tx Transfer Counter */
+  uint32_t                TxXferCount;    /* SPI Tx Transfer Counter */
 
   uint8_t                 *pRxBuffPtr;    /* Pointer to SPI Rx transfer Buffer */
 
-  uint16_t                RxXferSize;     /* SPI Rx Transfer size */
+  uint32_t                RxXferSize;     /* SPI Rx Transfer size */
 
-  uint16_t                RxXferCount;    /* SPI Rx Transfer Counter */
+  uint32_t                RxXferCount;    /* SPI Rx Transfer Counter */
 
   uint32_t                CRCSize;        /* SPI CRC size used for the transfer */
 
@@ -639,15 +639,15 @@ void HAL_SPI_MspDeInit(SPI_HandleTypeDef *hspi);
   */
 
 /* IO operation functions *****************************************************/
-HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size, uint32_t Timeout);
-HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size, uint32_t Timeout);
-HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size, uint32_t Timeout);
-HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);
-HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);
-HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size);
-HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);
-HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);
-HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size);
+HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint32_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint32_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint32_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint32_t Size);
+HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint32_t Size);
+HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint32_t Size);
+HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint32_t Size);
+HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint32_t Size);
+HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint32_t Size);
 HAL_StatusTypeDef HAL_SPI_DMAPause(SPI_HandleTypeDef *hspi);
 HAL_StatusTypeDef HAL_SPI_DMAResume(SPI_HandleTypeDef *hspi);
 HAL_StatusTypeDef HAL_SPI_DMAStop(SPI_HandleTypeDef *hspi);

--- a/arduino/opencr_arduino/opencr/variants/OpenCR/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_spi.c
+++ b/arduino/opencr_arduino/opencr/variants/OpenCR/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_spi.c
@@ -403,7 +403,7 @@ HAL_StatusTypeDef HAL_SPI_DeInit(SPI_HandleTypeDef *hspi)
   * @param  Timeout: Timeout duration
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint32_t Size, uint32_t Timeout)
 {
   assert_param(IS_SPI_DIRECTION_2LINES_OR_1LINE(hspi->Init.Direction));
 
@@ -548,7 +548,7 @@ HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint
   * @param  Timeout: Timeout duration
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint32_t Size, uint32_t Timeout)
 {
   __IO uint16_t tmpreg;
   
@@ -742,7 +742,7 @@ HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint1
   * @param  Timeout: Timeout duration
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size, uint32_t Timeout)
+HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint32_t Size, uint32_t Timeout)
 {
   __IO uint16_t tmpreg = 0;
   uint32_t tickstart = HAL_GetTick();
@@ -968,7 +968,7 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
   * @param  Size: amount of data to be sent
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size)
+HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint32_t Size)
 {
   assert_param(IS_SPI_DIRECTION_2LINES_OR_1LINE(hspi->Init.Direction));
   
@@ -1048,7 +1048,7 @@ HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, u
   * @param  Size: amount of data to be sent
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size)
+HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint32_t Size)
 {
   if(hspi->State == HAL_SPI_STATE_READY)
   {
@@ -1154,7 +1154,7 @@ HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, ui
   * @param  Size: amount of data to be sent and received
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size)
+HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint32_t Size)
 {
   assert_param(IS_SPI_DIRECTION_2LINES(hspi->Init.Direction));
   
@@ -1251,7 +1251,7 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, uint8_t *p
   * @param  Size: amount of data to be sent
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size)
+HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint32_t Size)
 {    
   assert_param(IS_SPI_DIRECTION_2LINES_OR_1LINE(hspi->Init.Direction));
 
@@ -1341,7 +1341,7 @@ HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, 
 * @param  Size: amount of data to be sent
 * @retval HAL status
 */
-HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size)
+HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint32_t Size)
 {
   if(hspi->State != HAL_SPI_STATE_READY)
   {
@@ -1362,7 +1362,7 @@ HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, u
   hspi->RxXferSize  = Size;
   hspi->RxXferCount = Size;
   hspi->pTxBuffPtr  = (uint8_t *)NULL;
-  hspi->TxXferSize  = 0;
+  hspi->TxXferSize  = 0;  //???
   hspi->TxXferCount = 0;
 
   if((hspi->Init.Mode == SPI_MODE_MASTER) && (hspi->Init.Direction == SPI_DIRECTION_2LINES))
@@ -1445,17 +1445,27 @@ HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, u
   * @param  Size: amount of data to be sent
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size)
+static uint8_t pRxDummy[1]; 
+static uint8_t pTxDummy[1] = {0};  // currently hard coded to send 0's 
+
+HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint32_t Size)
 {
   assert_param(IS_SPI_DIRECTION_2LINES(hspi->Init.Direction));
-  
+
   if((hspi->State == HAL_SPI_STATE_READY) ||
      ((hspi->Init.Mode == SPI_MODE_MASTER) && (hspi->Init.Direction == SPI_DIRECTION_2LINES) && (hspi->State == HAL_SPI_STATE_BUSY_RX)))
   {
-    if((pTxData == NULL ) || (pRxData == NULL ) || (Size == 0)) 
+//    if((pTxData == NULL ) || (pRxData == NULL ) || (Size == 0)) 
+    if(Size == 0)
     {
       return  HAL_ERROR;                                    
     }
+    // HAL_GPIO_WritePin(GPIOC, GPIO_PIN_6, 1);    // digitalWrite(1, HIGH);
+
+//    // More tests
+//    if (pTxDummy[0] != 0) {
+//        vcp_printf("HSP TRDMA: %x!=0\n", pTxDummy[0]);
+//    }
     
     /* Process locked */
     __HAL_LOCK(hspi);
@@ -1468,9 +1478,25 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *
     
     hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
     hspi->pTxBuffPtr  = (uint8_t *)pTxData;
+    if (pTxData)
+    {
+      SET_BIT(hspi->hdmatx->Instance->CR, DMA_SxCR_MINC);
+    } else {
+      pTxData  = (uint8_t *)pTxDummy;   // Send a constant value out
+      CLEAR_BIT(hspi->hdmatx->Instance->CR, DMA_SxCR_MINC);
+    }
+
     hspi->TxXferSize  = Size;
     hspi->TxXferCount = Size;
+    // check to see if user passed in buffer?
     hspi->pRxBuffPtr  = (uint8_t *)pRxData;
+    if (pRxData) 
+    {
+      SET_BIT(hspi->hdmarx->Instance->CR, DMA_SxCR_MINC);
+    } else {
+      pRxData  = (uint8_t *)pRxDummy;   // Use dummy to receive
+      CLEAR_BIT(hspi->hdmarx->Instance->CR, DMA_SxCR_MINC);
+    }
     hspi->RxXferSize  = Size;
     hspi->RxXferCount = Size;
     
@@ -1537,7 +1563,7 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *
     }
     else
     {	
-       hspi->hdmarx->XferHalfCpltCallback = SPI_DMAHalfTransmitReceiveCplt;
+      hspi->hdmarx->XferHalfCpltCallback = SPI_DMAHalfTransmitReceiveCplt;
       hspi->hdmarx->XferCpltCallback = SPI_DMATransmitReceiveCplt;
     }
     /* Set the DMA error callback */
@@ -1547,7 +1573,7 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *
     hspi->Instance->CR2 |= SPI_CR2_RXDMAEN;
     
     /* Enable the Rx DMA channel */
-    HAL_DMA_Start_IT(hspi->hdmarx, (uint32_t)&hspi->Instance->DR, (uint32_t) hspi->pRxBuffPtr, hspi->RxXferCount);
+    HAL_DMA_Start_IT(hspi->hdmarx, (uint32_t)&hspi->Instance->DR, (uint32_t)pRxData, hspi->RxXferCount);
     
     /* Set the SPI Tx DMA transfer complete callback as NULL because the communication closing
     is performed in DMA reception complete callback  */
@@ -1565,7 +1591,7 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *
     } 
     
     /* Enable the Tx DMA channel */
-    HAL_DMA_Start_IT(hspi->hdmatx, (uint32_t)hspi->pTxBuffPtr, (uint32_t)&hspi->Instance->DR, hspi->TxXferCount);
+    HAL_DMA_Start_IT(hspi->hdmatx, (uint32_t)pTxData, (uint32_t)&hspi->Instance->DR, hspi->TxXferCount);
 
     /* Process Unlocked */
     __HAL_UNLOCK(hspi);
@@ -1580,6 +1606,7 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *
     /* Enable Tx DMA Request */  
     hspi->Instance->CR2 |= SPI_CR2_TXDMAEN;
         
+    // HAL_GPIO_WritePin(GPIOC, GPIO_PIN_6, 0);    // digitalWrite(1, HIGH);
     return HAL_OK;
   }
   else
@@ -1901,6 +1928,7 @@ uint32_t HAL_SPI_GetError(SPI_HandleTypeDef *hspi)
   */
 static void SPI_DMATransmitCplt(DMA_HandleTypeDef *hdma)
 {
+//  HAL_GPIO_WritePin(GPIOC, GPIO_PIN_6, 1);    // digitalWrite(1, HIGH);
   SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
 
   /* DMA Normal Mode */
@@ -1925,6 +1953,7 @@ static void SPI_DMATransmitCplt(DMA_HandleTypeDef *hdma)
     }
   }
   HAL_SPI_TxCpltCallback(hspi);
+//  HAL_GPIO_WritePin(GPIOC, GPIO_PIN_6, 0);    // digitalWrite(1, LOW);
 }
 
 /**
@@ -1937,6 +1966,7 @@ static void SPI_DMAReceiveCplt(DMA_HandleTypeDef *hdma)
 {
   __IO uint16_t tmpreg;
   SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+//  HAL_GPIO_WritePin(GPIOC, GPIO_PIN_6, 1);    // digitalWrite(1, HIGH);
   
   /* DMA Normal mode */
   if((hdma->Instance->CR & DMA_SxCR_CIRC) == 0)
@@ -2007,6 +2037,7 @@ static void SPI_DMAReceiveCplt(DMA_HandleTypeDef *hdma)
   {
     HAL_SPI_RxCpltCallback(hspi);
   }
+//  HAL_GPIO_WritePin(GPIOC, GPIO_PIN_6, 0);    // digitalWrite(1, LOW);
 }
 
 /**
@@ -2017,6 +2048,7 @@ static void SPI_DMAReceiveCplt(DMA_HandleTypeDef *hdma)
   */
 static void SPI_DMATransmitReceiveCplt(DMA_HandleTypeDef *hdma)
 {
+//  HAL_GPIO_WritePin(GPIOC, GPIO_PIN_6, 1);    // digitalWrite(1, HIGH);
   __IO int16_t tmpreg;
   SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
   
@@ -2076,6 +2108,7 @@ static void SPI_DMATransmitReceiveCplt(DMA_HandleTypeDef *hdma)
       HAL_SPI_ErrorCallback(hspi);
     }
   }
+//  HAL_GPIO_WritePin(GPIOC, GPIO_PIN_6, 0);    // digitalWrite(1, HIGH);
 }
 
 /**

--- a/arduino/opencr_arduino/opencr/variants/OpenCR/variant.cpp
+++ b/arduino/opencr_arduino/opencr/variants/OpenCR/variant.cpp
@@ -98,10 +98,10 @@ extern const Pin2PortMapArray g_Pin2PortMapArray[]=
     {GPIOE, GPIO_PIN_3,   NULL,     NO_ADC        , NULL   ,   NO_PWM       , NO_EXTI },  // 54 BDPIN_GPIO_5
     {GPIOG, GPIO_PIN_2,   NULL,     NO_ADC        , NULL   ,   NO_PWM       , NO_EXTI },  // 55 BDPIN_GPIO_6
     {GPIOE, GPIO_PIN_10,  NULL,     NO_ADC        , NULL   ,   NO_PWM       , NO_EXTI },  // 56 BDPIN_GPIO_7
-    {GPIOE, GPIO_PIN_11,  NULL,     NO_ADC        , &hTIM1 ,   TIM_CHANNEL_2, NO_EXTI },  // 57 BDPIN_GPIO_8
-    {GPIOE, GPIO_PIN_12,  NULL,     NO_ADC        , NULL   ,   NO_PWM       , NO_EXTI },  // 58 BDPIN_GPIO_9
-    {GPIOE, GPIO_PIN_13,  NULL,     NO_ADC        , NULL   ,   NO_PWM       , NO_EXTI },  // 59 BDPIN_GPIO_10
-    {GPIOE, GPIO_PIN_14,  NULL,     NO_ADC        , NULL   ,   NO_PWM       , NO_EXTI },  // 60 BDPIN_GPIO_11
+    {GPIOE, GPIO_PIN_11,  NULL,     NO_ADC        , &hTIM1 ,   TIM_CHANNEL_2, NO_EXTI },  // 57 BDPIN_GPIO_8  SPI4_NSS
+    {GPIOE, GPIO_PIN_12,  NULL,     NO_ADC        , NULL   ,   NO_PWM       , NO_EXTI },  // 58 BDPIN_GPIO_9  SPI4_SCK
+    {GPIOE, GPIO_PIN_13,  NULL,     NO_ADC        , NULL   ,   NO_PWM       , NO_EXTI },  // 59 BDPIN_GPIO_10 SPI4_MISO
+    {GPIOE, GPIO_PIN_14,  NULL,     NO_ADC        , NULL   ,   NO_PWM       , NO_EXTI },  // 60 BDPIN_GPIO_11 SPI4_MOSI
     {GPIOE, GPIO_PIN_15,  NULL,     NO_ADC        , NULL   ,   NO_PWM       , NO_EXTI },  // 61 BDPIN_GPIO_12
     {GPIOF, GPIO_PIN_0,   NULL,     NO_ADC        , NULL   ,   NO_PWM       , NO_EXTI },  // 62 BDPIN_GPIO_13
     {GPIOF, GPIO_PIN_1,   NULL,     NO_ADC        , NULL   ,   NO_PWM       , NO_EXTI },  // 63 BDPIN_GPIO_14


### PR DESCRIPTION
**Warning:** There are lots of changes here, that you probably want to carefully look at, including the idea of using a very reduced functionality of the Teensy EventResponder for doing callbacks.  Could use simple callback function if desired, but made it so I could use the modified Sparkfun_TeensyView async support.

I have done some different testings, including my own test apps, ran some of the IMU tests to hopefully make sure I did not mess it up.    Looks like by accident I put in a change to rename the board to include the name (develop).  I use this so I can use the trick to add a board to the Arduino using a symbolic link from arduino folder/hardware and have both the changed version and the released version in the tools/boards list and be able to tell which one is which. 

Remove compiler warnings on using Serial.printf... 


Added SPI4 (SPI_EXT) on IO pins 57-60

Added SPI.transfer(txbuf, rxbuf, count) - where either RX or TX can be NULL...

Changed SPI.writeFast to call this transfer - DMA was not actually any faster.

Added ASYNC SPI (DMA) method:
SPI.transfer(txbuf, rxbuf, count, event_responder)
This uses a Teensy (PJRC) WIP Async api (EventResponder) which I removed the majority of the possible ways of using (only calls directly).

Changes SPI.beginTrasaction - SPISettings to remember the desired clock instead of clock divider and added SPI.setClock() which is used by beginTransaction. This was needed as SPI (SPI2) - has a max speed of 25mhz whereas the SPI_EXT(SPI4) has a max speed of 50mhz (so does SPI_IMU(SPI1)... So since the SPISettings in theory could be shared, needed way change depending on which one...

Fixed some of the intenal SSPI Transfer functions to allow transfers over 64K.