### PR TITLE
Wire develop

### DIFF
--- a/arduino/opencr_arduino/opencr/libraries/Wire/Wire.cpp
+++ b/arduino/opencr_arduino/opencr/libraries/Wire/Wire.cpp
@@ -9,7 +9,11 @@
 
 #include <Wire.h>
 
+#ifdef USE_SLOW_SOFT_I2C_MASTER
 
+//=============================================================================
+// Software I2C - master only
+//=============================================================================
 TwoWire::TwoWire(uint8_t sda, uint8_t scl) {
   si2c = new SlowSoftI2CMaster(sda, scl);
 }
@@ -34,9 +38,11 @@ void TwoWire::begin(uint8_t sda_pin, uint8_t scl_pin) {
 
 void  TwoWire::end(void) {
   free(si2c);
+  si2c = NULL;
 }
 
-void  TwoWire::setClock(uint32_t _) {
+void  TwoWire::setClock(uint32_t frequency) {
+  UNUSED(frequency);  // Change at some point?
 }
 
 void  TwoWire::beginTransmission(uint8_t address) {
@@ -167,6 +173,660 @@ int TwoWire::peek(void) {
 void TwoWire::flush(void) {
 }
 
-
-
 TwoWire Wire(14, 15);
+
+
+#else
+//=============================================================================
+// Hardware I2C
+//=============================================================================
+#ifdef WIRE_USE_DEBUG_IO_PINS
+#include <digitalWriteFast.h>
+#define debugDigitalWrite(pin, value) digitalWriteFast((pin), (value))
+#else
+#define debugDigitalWrite(pin, value)
+#endif
+
+
+#define I2C_TIMEOUT_ADDR    ((uint32_t)10000)       /* 10 s  */
+#define I2C_TIMEOUT_BUSY    ((uint32_t)25)          /* 25 ms */
+#define I2C_TIMEOUT_DIR     ((uint32_t)25)          /* 25 ms */
+#define I2C_TIMEOUT_RXNE    ((uint32_t)25)          /* 25 ms */
+#define I2C_TIMEOUT_STOPF   ((uint32_t)25)          /* 25 ms */
+#define I2C_TIMEOUT_TC      ((uint32_t)25)          /* 25 ms */
+#define I2C_TIMEOUT_TCR     ((uint32_t)25)          /* 25 ms */
+#define I2C_TIMEOUT_TXIS    ((uint32_t)25)          /* 25 ms */
+#define I2C_TIMEOUT_FLAG    ((uint32_t)25)          /* 25 ms */
+
+
+
+TwoWire::TwoWire(I2C_HandleTypeDef *hi2c) {
+  hi2c_ = hi2c; // remember the i2c object
+  
+  // Init some of the I2C Handle init structure. 
+  hi2c_->Init.OwnAddress1     = 0x00;  // Lets init the whole structure.
+  hi2c_->Init.AddressingMode  = I2C_ADDRESSINGMODE_7BIT;
+  hi2c_->Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
+  hi2c_->Init.OwnAddress2     = 0xFF;
+  hi2c_->Init.OwnAddress2Masks  = I2C_OA2_NOMASK;
+  hi2c_->Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
+  hi2c_->Init.NoStretchMode   = I2C_NOSTRETCH_DISABLE;
+  user_onRequest = NULL;
+  user_onReceive = NULL;
+
+  frequency_ = 100000;
+  state_ = 0; // Begin has not been called. 
+}
+
+
+void TwoWire::begin(void) {
+  hi2c_->Init.OwnAddress1 = 0x00;
+
+  rxBufferIndex = 0;
+  rxBufferLength = 0;
+  txBufferIndex = 0;
+  txBufferLength = 0;
+  error = 0;
+  slave_mode = 0;
+  transmitting = false;
+  state_ = 1;
+#ifdef WIRE_USE_DEBUG_IO_PINS
+  pinMode(WIRE_DEBUG_RECEIVE_FROM, OUTPUT);
+  digitalWriteFast(WIRE_DEBUG_RECEIVE_FROM, LOW);
+#endif
+  setClock(frequency_);   // set the clock.
+}
+
+void TwoWire::begin(uint8_t address) {
+  // TODO: Implement slave mode. 
+  hi2c_->Init.OwnAddress1 = address << 1;  // 7 bit passed in
+  rxBufferIndex = 0;
+  rxBufferLength = 0;
+  txBufferIndex = 0;
+  txBufferLength = 0;
+  error = 0;
+  slave_mode = 1;  // Need to see how to update slave address and direction with init?
+  transmitting = false;
+  state_ = 1;
+  setClock(frequency_);   // set the clock.
+
+  // Setup to get interrupt when we get a slave address match
+  HAL_I2C_Slave_Addr_IT(hi2c_);  
+}
+
+
+void  TwoWire::end(void) {
+  HAL_I2C_DeInit(hi2c_);
+  state_ = 0;
+}
+
+void  TwoWire::setClock(uint32_t frequency) {
+  if (state_) {
+    // BUGBUG: Need to figure this out more...
+    if     (frequency <  400000 ) hi2c_->Init.Timing = 0x40912732; // Ask for something < 400K use 100K
+    else if(frequency < 1000000 ) hi2c_->Init.Timing = 0x40940607; // Ask for someting under 1000K so use 400K
+    else                          hi2c_->Init.Timing = 0x00200922; // 0x50310001; // Ask for 1000K+ try to give 1000K
+
+    HAL_StatusTypeDef hal_status;
+    if ((hal_status = HAL_I2C_Init(hi2c_)) != HAL_OK) {  // Maybe should check for success...
+      //Serial.printf("HAL_I2C_Init failed: %d\n", (int)hal_status);
+    }
+    /* Enable the Analog I2C Filter */
+    HAL_I2CEx_ConfigAnalogFilter(hi2c_,I2C_ANALOGFILTER_ENABLE);
+  } else {
+    frequency_ = frequency; // remember it away. 
+  }
+}
+
+void  TwoWire::beginTransmission(uint8_t address) {
+  device_address = address << 1; // save away the address, preshift it
+  transmitting = 1;
+  txBufferLength = 0;
+}
+
+void  TwoWire::beginTransmission(int address) {
+  beginTransmission((uint8_t)address);
+}
+
+
+uint8_t  TwoWire::endTransmission(uint8_t sendStop)
+{
+  // Not sure how to control if send stop or not?
+  if (transmitting) {
+    //status = HAL_I2C_Master_Transmit(hi2c_, device_address<<1, txBuffer, txBufferLength, WIRE_TX_TIMEOUT);
+    uint8_t *pData = txBuffer;
+    uint16_t Size = txBufferLength;
+  
+    if(hi2c_->State != HAL_I2C_STATE_READY) return HAL_BUSY;    
+    if(__HAL_I2C_GET_FLAG(hi2c_, I2C_FLAG_BUSY) == SET) return HAL_BUSY;
+    /* Process Locked */
+    __HAL_LOCK(hi2c_);
+    
+    hi2c_->State = HAL_I2C_STATE_MASTER_BUSY_TX;
+    hi2c_->ErrorCode   = HAL_I2C_ERROR_NONE;
+    
+    // Now lets build the CR2 register. 
+    // Mode will depend on if sendStop is set
+    transferConfig(device_address,txBufferLength, sendStop? I2C_AUTOEND_MODE : I2C_SOFTEND_MODE, 
+        I2C_GENERATE_START_WRITE);
+
+    while(Size > 0) {
+      /* Wait until TXIS flag is set */
+      if(waitOnTXISFlagUntilTimeout(WIRE_TX_TIMEOUT) != HAL_OK) {
+        if(hi2c_->ErrorCode == HAL_I2C_ERROR_AF) {
+          return HAL_ERROR; 
+        } else {
+          return HAL_TIMEOUT;
+        }
+      }
+
+      /* Write data to TXDR */
+      hi2c_->Instance->TXDR = (*pData++);
+      Size--;
+    }
+    
+    // Check to see which flag we should get at the end...
+    if (sendStop) {
+      if(waitOnFlagUntilTimeout( I2C_FLAG_STOPF, I2C_TIMEOUT_STOPF) != HAL_OK) {
+        if(hi2c_->ErrorCode == HAL_I2C_ERROR_AF) {
+          return HAL_ERROR; 
+        } else {
+          return HAL_TIMEOUT;
+        }
+      }
+      __HAL_I2C_CLEAR_FLAG(hi2c_, I2C_FLAG_STOPF);
+  
+      /* Clear Configuration Register 2 */
+      I2C_RESET_CR2(hi2c_);
+    } else {
+      // not generating stop so wait until Transfer compelte
+      if(waitOnFlagUntilTimeout(I2C_FLAG_TC, WIRE_TX_TIMEOUT) != HAL_OK) {
+        if(hi2c_->ErrorCode == HAL_I2C_ERROR_AF) {
+          return HAL_ERROR; 
+        } else {
+          return HAL_TIMEOUT;
+        }
+      }
+      // Not sure if we need to reset CR2?  or wait for stop condtion? 
+      // Assuming not and next transfer will do it.
+    }
+  
+    hi2c_->State = HAL_I2C_STATE_READY;    
+  
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c_);
+
+    transmitting = false; 
+  }
+  return 0; 
+}
+
+//  This provides backwards compatibility with the original
+//  definition, and expected behaviour, of endTransmission
+//
+uint8_t  TwoWire::endTransmission(void)
+{
+  return endTransmission(true);
+}
+
+size_t  TwoWire::write(uint8_t data) {
+  if (transmitting || slave_mode) {
+    if (txBufferLength >= BUFFER_LENGTH+1) {
+      setWriteError();
+      return 0;
+    }
+    txBuffer[txBufferLength++] = data;
+    return 1;
+  }
+  return 0;
+}
+
+size_t  TwoWire::write(const uint8_t *data, size_t quantity) {
+  size_t trans = 0;
+  for(size_t i = 0; i < quantity; ++i){
+    trans += write(data[i]);
+  }
+  return trans;
+}
+
+#ifdef LATER
+uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity,
+        uint32_t iaddress, uint8_t isize, uint8_t sendStop) {
+}
+#endif
+
+uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint8_t sendStop) {
+  // Hardware I2C... 
+  rxBufferIndex = 0;
+  rxBufferLength = 0;
+  uint8_t *data_in_ptr = rxBuffer;
+  if (quantity > sizeof(rxBuffer)) {
+    quantity = sizeof(rxBuffer);
+  }
+  uint8_t count_left_to_read = quantity;
+
+  if(hi2c_->State == HAL_I2C_STATE_READY)
+  {    
+    if(__HAL_I2C_GET_FLAG(hi2c_, I2C_FLAG_BUSY) == SET)
+    {
+      //Serial.println("TwoWire::requestFrom Busy");
+      return 0; //HAL_BUSY;
+    }
+    
+    /* Process Locked */
+    __HAL_LOCK(hi2c_);
+    
+    hi2c_->State = HAL_I2C_STATE_MASTER_BUSY_RX;
+    hi2c_->ErrorCode   = HAL_I2C_ERROR_NONE;
+    
+    transferConfig(address<<1,  quantity, sendStop? I2C_AUTOEND_MODE : I2C_SOFTEND_MODE, 
+        I2C_GENERATE_START_READ);
+    
+    do
+    {
+      /* Wait until RXNE flag is set */
+      HAL_StatusTypeDef hstatus;
+      if((hstatus = waitOnRXNEFlagUntilTimeout(I2C_TIMEOUT_RXNE)) != HAL_OK) {
+          //Serial.printf("TwoWire::requestFrom RXNE %d %d\n", hstatus, count_left_to_read);
+          rxBufferLength = quantity - count_left_to_read;  // BUGBUG: seeing what was actually read
+
+          return 0; // an error
+      }       
+      
+      /* Write data to RXDR */
+
+      debugDigitalWrite(WIRE_DEBUG_RECEIVE_FROM, HIGH);
+      (*data_in_ptr++) =hi2c_->Instance->RXDR;
+      count_left_to_read--;
+      debugDigitalWrite(WIRE_DEBUG_RECEIVE_FROM, LOW);
+
+    } while(count_left_to_read > 0);
+    
+
+    if (sendStop) {
+      /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+      /* Wait until STOPF flag is set */
+      if(waitOnFlagUntilTimeout( I2C_FLAG_STOPF, I2C_TIMEOUT_STOPF) != HAL_OK) {
+        //Serial.println("TwoWire::requestFrom STOPF");
+        return 0; // no bytes
+      }
+      
+      /* Clear STOP Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c_, I2C_FLAG_STOPF);
+      
+      /* Clear Configuration Register 2 */
+      I2C_RESET_CR2(hi2c_);
+    } else {
+      // not generating stop so wait until Transfer compelte
+      if(waitOnFlagUntilTimeout(I2C_FLAG_TC, WIRE_TX_TIMEOUT) != HAL_OK) {
+        if(hi2c_->ErrorCode == HAL_I2C_ERROR_AF) {
+          return HAL_ERROR; 
+        } else {
+          return HAL_TIMEOUT;
+        }
+      }
+      // Not sure if we need to reset CR2?  or wait for stop condtion? 
+      // Assuming not and next transfer will do it.
+    }    
+    hi2c_->State = HAL_I2C_STATE_READY;    
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c_);
+    rxBufferLength = quantity;
+    
+    return quantity;
+  }
+  //Serial.println("TwoWire::requestFrom not Ready");
+  return 0;  // An error so say we did not receive anything.  
+}
+
+uint8_t TwoWire::requestFrom(int address, int quantity, int sendStop) {
+  return requestFrom((uint8_t)address, (uint8_t)quantity, (uint8_t)sendStop);
+}
+
+
+uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity) {
+  return requestFrom((uint8_t)address, (uint8_t)quantity, (uint8_t)true);
+}
+
+uint8_t TwoWire::requestFrom(int address, int quantity) {
+  return requestFrom((uint8_t)address, (uint8_t)quantity, (uint8_t)true);
+}
+
+int TwoWire::available(void) {
+  return rxBufferLength - rxBufferIndex;
+}
+
+int TwoWire::read(void) {
+  int value = -1;
+  if(rxBufferIndex < rxBufferLength){
+    value = rxBuffer[rxBufferIndex];
+    ++rxBufferIndex;
+  }
+  return value;
+}
+
+int TwoWire::peek(void) {
+  int value = -1;
+
+  if(rxBufferIndex < rxBufferLength){
+    value = rxBuffer[rxBufferIndex];
+  }
+  return value;
+}
+
+void TwoWire::flush(void) {
+}
+
+
+void TwoWire::onReceive(void (*function)(int numBytes)) {
+  user_onReceive = function;
+}
+
+void TwoWire::onRequest(void (*function)(void)) {
+  user_onRequest = function;
+}
+
+//=============================================================================
+// Callback functions from HAL I2C
+//=============================================================================
+
+//-------------------------------------
+// Process Address match
+//-------------------------------------
+void HAL_I2C_SlaveAddrCpltCallback(I2C_HandleTypeDef *hi2c) {
+  if (hi2c == Wire.hi2c_) {
+    Wire.processAddrCallback();
+  } else if (hi2c == Wire1.hi2c_ )
+    Wire1.processAddrCallback();  
+}
+
+// Process Address select callback
+void TwoWire::processAddrCallback(void) {
+  // lets check to see they are writing data to us or wanting data from us
+  if (__HAL_I2C_GET_FLAG(hi2c_, I2C_FLAG_DIR) == SET) {
+    // We received request from other side, so, lets call of to our 
+    // users call back to let them put data into TX buffer.  
+    // Not sure if we should clear buffer first?  Will start off doing so
+    txBufferIndex = 0;
+    txBufferLength = 0;
+    if (user_onRequest) {
+      (*user_onRequest)();
+      __HAL_I2C_SET_FLAG(hi2c_, I2C_FLAG_TXE); // Clear out anything that was previously in TXDR
+      HAL_I2C_Slave_Transmit_IT(hi2c_, txBuffer, txBufferLength);
+    }
+
+  } else {
+    // They are sending us data setup to do receive...
+    HAL_I2C_Slave_Receive_IT(hi2c_, rxBuffer, sizeof(rxBuffer));
+  }
+}
+
+
+//-------------------------------------
+// Process slave receiving data complete
+//-------------------------------------
+void HAL_I2C_SlaveRxCpltCallback(I2C_HandleTypeDef *hi2c) {
+  // map this handle to which Wire object
+  if (hi2c == Wire.hi2c_) {
+    Wire.processRXCallback();
+  } else if (hi2c == Wire1.hi2c_ )
+    Wire1.processRXCallback();  
+}
+
+void TwoWire::processRXCallback(void) {
+  // Lets see if we can figure out what happened...
+  rxBufferLength = (uint32_t)(hi2c_->pBuffPtr-rxBuffer);
+  rxBufferIndex = 0;  // setup the index to first one
+//  Serial.printf("ProcessRXCallback: %x %x %x %d\n", (uint32_t)hi2c_->pBuffPtr,
+//    hi2c_->XferSize, hi2c_->XferCount, rxBufferLength);
+
+  if (user_onReceive) {
+    (*user_onReceive)(rxBufferLength);
+  }
+  // Setup to try to receive next message.
+   HAL_I2C_Slave_Addr_IT(hi2c_);
+}
+
+//-------------------------------------
+// Process slave transmit data complete
+//-------------------------------------
+void HAL_I2C_SlaveTxCpltCallback(I2C_HandleTypeDef *hi2c) {
+  // Called at the end of Slave Trransmit - setup to handle next Address match
+   HAL_I2C_Slave_Addr_IT(hi2c);
+}
+
+//-------------------------------------
+// Process HAL errors detected
+//-------------------------------------
+void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *hi2c) {
+  UNUSED(hi2c);
+  //Serial.println("HAL_I2C_ErrorCallback called");
+}
+
+
+//=============================================================================
+// Helper functions from stm32fxx_hal_i2c.c
+//=============================================================================
+HAL_StatusTypeDef TwoWire::waitOnTXISFlagUntilTimeout(uint32_t Timeout)  
+{  
+  uint32_t tickstart = HAL_GetTick();
+  
+  while(__HAL_I2C_GET_FLAG(hi2c_, I2C_FLAG_TXIS) == RESET)
+  {
+    /* Check if a NACK is detected */
+    if(isAcknowledgeFailed(Timeout) != HAL_OK)
+    {
+      return HAL_ERROR;
+    }
+    
+    /* Check for the Timeout */
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hi2c_->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+        hi2c_->State= HAL_I2C_STATE_READY;
+        
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c_);
+        
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+  return HAL_OK;      
+}
+
+
+HAL_StatusTypeDef TwoWire::waitOnRXNEFlagUntilTimeout(uint32_t Timeout)
+{  
+  uint32_t tickstart = 0x00;
+  tickstart = HAL_GetTick();
+  
+  while(__HAL_I2C_GET_FLAG(hi2c_, I2C_FLAG_RXNE) == RESET)
+  {
+    /* Check if a NACK is detected */
+    if(isAcknowledgeFailed(Timeout) != HAL_OK)
+    {
+      //Serial.println("NACK");
+      return HAL_ERROR;
+    }
+    
+    // See if it was set during the wait for ACK...
+    if(__HAL_I2C_GET_FLAG(hi2c_, I2C_FLAG_RXNE) != RESET) 
+    {
+      break;  // Data is available so break out of loop
+    }
+
+    /* Check if a STOPF is detected */
+    if(__HAL_I2C_GET_FLAG(hi2c_, I2C_FLAG_STOPF) == SET)
+    {
+      /* Clear STOP Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c_, I2C_FLAG_STOPF);
+      
+      /* Clear Configuration Register 2 */
+      I2C_RESET_CR2(hi2c_);
+      
+      hi2c_->ErrorCode = HAL_I2C_ERROR_NONE;
+      hi2c_->State= HAL_I2C_STATE_READY;
+      
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c_);
+      
+      //Serial.println("STOPF");
+      return HAL_ERROR;
+    }
+    
+    /* Check for the Timeout */
+    if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+    {
+      hi2c_->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      hi2c_->State= HAL_I2C_STATE_READY;
+      
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c_);
+      
+      return HAL_TIMEOUT;
+    }
+  }
+  return HAL_OK;
+}
+
+
+
+HAL_StatusTypeDef TwoWire::waitOnFlagUntilTimeout(uint32_t flag, uint32_t Timeout)
+{  
+  uint32_t tickstart = 0x00;
+  tickstart = HAL_GetTick();
+  
+  while(__HAL_I2C_GET_FLAG(hi2c_, flag) == RESET)
+  {
+    /* Check if a NACK is detected */
+    if(isAcknowledgeFailed(Timeout) != HAL_OK)
+    {
+      return HAL_ERROR;
+    }
+    
+    /* Check for the Timeout */
+    if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+    {
+      hi2c_->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      hi2c_->State= HAL_I2C_STATE_READY;
+      
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c_);
+      
+      return HAL_TIMEOUT;
+    }
+  }
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  This function handles Acknowledge failed detection during an I2C Communication.
+  * @param  hi2c_ : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef TwoWire::isAcknowledgeFailed(uint32_t Timeout)
+{
+  uint32_t tickstart = 0x00;
+  tickstart = HAL_GetTick();
+  
+  if(__HAL_I2C_GET_FLAG(hi2c_, I2C_FLAG_AF) == SET)
+  {
+    /* Wait until STOP Flag is reset */
+    /* AutoEnd should be initiate after AF */
+    while(__HAL_I2C_GET_FLAG(hi2c_, I2C_FLAG_STOPF) == RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          hi2c_->State= HAL_I2C_STATE_READY;
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2c_);
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+    
+    /* Clear NACKF Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c_, I2C_FLAG_AF);
+    
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c_, I2C_FLAG_STOPF);
+    
+    /* Flush TX register if not empty */
+    if(__HAL_I2C_GET_FLAG(hi2c_, I2C_FLAG_TXE) == RESET)
+    {
+      __HAL_I2C_CLEAR_FLAG(hi2c_, I2C_FLAG_TXE);
+    }
+    
+    /* Clear Configuration Register 2 */
+    I2C_RESET_CR2(hi2c_);
+    
+    hi2c_->ErrorCode = HAL_I2C_ERROR_AF;
+    hi2c_->State= HAL_I2C_STATE_READY;
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c_);
+    
+    return HAL_ERROR;
+  }
+  return HAL_OK;
+}
+
+void TwoWire::transferConfig(uint16_t DevAddress, uint8_t Size, uint32_t Mode, uint32_t Request)
+{
+  uint32_t tmpreg = 0;
+  
+   /* Get the CR2 register value */
+  tmpreg = hi2c_->Instance->CR2;
+  
+  /* clear tmpreg specific bits */
+  tmpreg &= (uint32_t)~((uint32_t)(I2C_CR2_SADD | I2C_CR2_NBYTES | I2C_CR2_RELOAD | I2C_CR2_AUTOEND | I2C_CR2_RD_WRN | I2C_CR2_START | I2C_CR2_STOP));
+  
+  /* update tmpreg */
+  tmpreg |= (uint32_t)(((uint32_t)DevAddress & I2C_CR2_SADD) | (((uint32_t)Size << 16 ) & I2C_CR2_NBYTES) | \
+    (uint32_t)Mode | (uint32_t)Request);
+  
+  /* update CR2 register */
+  hi2c_->Instance->CR2 = tmpreg;  
+}  
+
+//=============================================================================
+// Set up IRQ handlers for the Wire objects...
+// Note: Should probably be in the HAL driver file, but this way only happens
+// if app includes wire. 
+//=============================================================================
+#if 0
+void I2C1_EV_IRQHandler(void) {
+  HAL_I2C_EV_IRQHandler(&Wire.i2c_handle_);
+}
+
+void I2C2_EV_IRQHandler(void)  {
+  HAL_I2C_EV_IRQHandler(&Wire1.i2c_handle_);
+}
+
+void I2C1_ER_IRQHandler(void) {
+  HAL_I2C_ER_IRQHandler(&Wire.i2c_handle_);
+}
+
+void I2C2_ER_IRQHandler(void)  {
+  HAL_I2C_ER_IRQHandler(&Wire1.i2c_handle_);
+}
+#endif
+
+//=============================================================================
+// Define our hardware I2C objects
+//=============================================================================
+
+TwoWire Wire(&drv_i2c_handles[0]);
+TwoWire Wire1(&drv_i2c_handles[1]);
+
+#endif

--- a/arduino/opencr_arduino/opencr/libraries/Wire/Wire.h
+++ b/arduino/opencr_arduino/opencr/libraries/Wire/Wire.h
@@ -80,7 +80,7 @@ public:
 // Some temporary DEBUG defines
 //#define WIRE_USE_DEBUG_IO_PINS  // If defined enables debug
 #define WIRE_DEBUG_RECEIVE_FROM 11
-
+#define WIRE_DEBUG_END_TRANSFER 9
 // Some default buffer length and timeouts 
 #define BUFFER_LENGTH 32
 #define WIRE_TX_TIMEOUT 1000 // timeout in ms
@@ -171,6 +171,7 @@ private:
   uint8_t error;
   uint8_t slave_mode;
   uint8_t state_;                      // What state are we in 0=not active 1=begin() called
+  uint8_t sendStop_;                  // Last communications do sendStop?
   I2C_HandleTypeDef *hi2c_;           // Handle to the hardware I2c...
   void (*user_onRequest)(void);
   void (*user_onReceive)(int);

--- a/arduino/opencr_arduino/opencr/libraries/Wire/Wire.h
+++ b/arduino/opencr_arduino/opencr/libraries/Wire/Wire.h
@@ -23,6 +23,7 @@
  * Arduino srl - www.arduino.org
  * 2016 Jun 9: Edited Francesco Alessi (alfran) - francesco@arduino.org
  */
+//#define USE_SLOW_SOFT_I2C_MASTER
 
 #ifndef TwoWire_h
 #define TwoWire_h
@@ -30,6 +31,7 @@
 #include "variant.h"
 #include <inttypes.h>
 #include "Stream.h"
+#ifdef USE_SLOW_SOFT_I2C_MASTER
 #include <SlowSoftI2CMaster.h>
 
 
@@ -47,7 +49,7 @@ public:
   void begin(void);
   void begin(uint8_t sda_pin, uint8_t scl_pin);
   void end(void);
-  void setClock(uint32_t _);
+  void setClock(uint32_t frequency);
   void beginTransmission(uint8_t address);
   void beginTransmission(int address);
   uint8_t endTransmission(uint8_t sendStop);
@@ -71,7 +73,115 @@ public:
   using Print::write;
 };
 
+#else  
+//=============================================================================
+// Lets try hardware I2C
+//=============================================================================
+// Some temporary DEBUG defines
+//#define WIRE_USE_DEBUG_IO_PINS  // If defined enables debug
+#define WIRE_DEBUG_RECEIVE_FROM 11
 
+// Some default buffer length and timeouts 
+#define BUFFER_LENGTH 32
+#define WIRE_TX_TIMEOUT 1000 // timeout in ms
+#define WIRE_RX_TIMEOUT 1000 // timeout in ms
+
+
+
+//=============================================================================
+// Define some external call backs and interrupt handlers
+//=============================================================================
+extern void HAL_I2C_SlaveRxCpltCallback(I2C_HandleTypeDef *hi2c);
+extern void HAL_I2C_SlaveAddrCpltCallback(I2C_HandleTypeDef *hi2c);
+extern "C" void I2C1_EV_IRQHandler(void);
+extern "C" void I2C2_EV_IRQHandler(void);
+extern "C" void I2C1_ER_IRQHandler(void);
+extern "C" void I2C2_ER_IRQHandler(void);
+
+//=============================================================================
+// TwoWire class definition
+//=============================================================================
+class TwoWire : public Stream
+{
+
+public:
+  friend void HAL_I2C_SlaveRxCpltCallback(I2C_HandleTypeDef *hi2c);
+  friend void HAL_I2C_SlaveAddrCpltCallback(I2C_HandleTypeDef *hi2c);
+  friend void I2C1_EV_IRQHandler(void);
+  friend void I2C2_EV_IRQHandler(void);
+  friend void I2C1_ER_IRQHandler(void);
+  friend void I2C2_ER_IRQHandler(void);
+
+  TwoWire(I2C_HandleTypeDef *hi2c);
+  void begin(void);
+  void begin(uint8_t address);
+  void begin(int address) {
+    begin((uint8_t)address);
+  }
+  void end(void);
+  void setClock(uint32_t frequency);
+  void beginTransmission(uint8_t address);
+  void beginTransmission(int address);
+  uint8_t endTransmission(uint8_t sendStop);
+  uint8_t endTransmission(void);
+  size_t write(uint8_t data);
+  size_t write(const uint8_t *data, size_t quantity);
+//  uint8_t requestFrom(uint8_t address, uint8_t quantity,
+//          uint32_t iaddress, uint8_t isize, uint8_t sendStop);
+  uint8_t requestFrom(uint8_t address, uint8_t quantity, uint8_t sendStop);
+  uint8_t requestFrom(int address, int quantity, int sendStop);
+  uint8_t requestFrom(uint8_t address, uint8_t quantity);
+  uint8_t requestFrom(int address, int quantity);
+  int available(void);
+  int read(void);
+  int peek(void);
+  void flush(void);
+  inline size_t write(unsigned long n) { return write((uint8_t)n); }
+  inline size_t write(long n) { return write((uint8_t)n); }
+  inline size_t write(unsigned int n) { return write((uint8_t)n); }
+  inline size_t write(int n) { return write((uint8_t)n); }
+  using Print::write;
+
+  void onReceive(void (*function)(int numBytes));
+  void onRequest(void (*function)(void));
+  // Process Client ISR Callbacks    
+  void processRXCallback(void);  
+  void processAddrCallback(void);
+
+
+private:
+  // Helper functions brought over from HAL I2C code
+  HAL_StatusTypeDef waitOnTXISFlagUntilTimeout(uint32_t Timeout);
+  HAL_StatusTypeDef waitOnRXNEFlagUntilTimeout(uint32_t Timeout);
+  HAL_StatusTypeDef waitOnFlagUntilTimeout(uint32_t flag, uint32_t Timeout);
+  HAL_StatusTypeDef isAcknowledgeFailed(uint32_t Timeout);
+
+  void transferConfig(uint16_t DevAddress, uint8_t Size, uint32_t Mode, uint32_t Request);
+
+  uint8_t rxBuffer[BUFFER_LENGTH];
+  uint8_t rxBufferIndex;
+  uint8_t rxBufferLength;
+
+  uint16_t device_address;
+  uint32_t frequency_;
+  uint8_t txBuffer[BUFFER_LENGTH];
+  uint8_t txBufferIndex;
+  uint8_t txBufferLength;
+  uint8_t transmitting;
+  uint8_t error;
+  uint8_t slave_mode;
+  uint8_t state_;                      // What state are we in 0=not active 1=begin() called
+  I2C_HandleTypeDef *hi2c_;           // Handle to the hardware I2c...
+  void (*user_onRequest)(void);
+  void (*user_onReceive)(int);
+
+};
+
+#endif
+//=============================================================================
+// Define standard objects
+//=============================================================================
 extern TwoWire Wire;
+extern TwoWire Wire1;
 
 #endif

--- a/arduino/opencr_arduino/opencr/platform.txt
+++ b/arduino/opencr_arduino/opencr/platform.txt
@@ -27,7 +27,7 @@ compiler.c.elf.flags=-Os -Wl,--gc-sections
 compiler.S.cmd=arm-none-eabi-gcc
 compiler.S.flags=-c -g -x assembler-with-cpp -MMD
 compiler.cpp.cmd=arm-none-eabi-g++
-compiler.cpp.flags=-c -g -O2 -std=gnu++14 -mfloat-abi=softfp -mfpu=fpv5-sp-d16 {compiler.warning_flags} -MMD -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -DBOARD_{build.variant}
+compiler.cpp.flags=-c -g -O2 -mfloat-abi=softfp -mfpu=fpv5-sp-d16 {compiler.warning_flags} -MMD -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -DBOARD_{build.variant}
 compiler.ar.cmd=arm-none-eabi-ar
 compiler.ar.flags=rcs
 compiler.objcopy.cmd=arm-none-eabi-objcopy

--- a/arduino/opencr_arduino/opencr/platform.txt
+++ b/arduino/opencr_arduino/opencr/platform.txt
@@ -27,7 +27,7 @@ compiler.c.elf.flags=-Os -Wl,--gc-sections
 compiler.S.cmd=arm-none-eabi-gcc
 compiler.S.flags=-c -g -x assembler-with-cpp -MMD
 compiler.cpp.cmd=arm-none-eabi-g++
-compiler.cpp.flags=-c -g -O2 -mfloat-abi=softfp -mfpu=fpv5-sp-d16 {compiler.warning_flags} -MMD -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -DBOARD_{build.variant}
+compiler.cpp.flags=-c -g -O2 -std=gnu++14 -mfloat-abi=softfp -mfpu=fpv5-sp-d16 {compiler.warning_flags} -MMD -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -DBOARD_{build.variant}
 compiler.ar.cmd=arm-none-eabi-ar
 compiler.ar.flags=rcs
 compiler.objcopy.cmd=arm-none-eabi-objcopy

--- a/arduino/opencr_arduino/opencr/variants/OpenCR/hw/driver/drv_i2c.c
+++ b/arduino/opencr_arduino/opencr/variants/OpenCR/hw/driver/drv_i2c.c
@@ -9,10 +9,15 @@
 #include "variant.h"
 
 
-
+I2C_HandleTypeDef drv_i2c_handles[DRV_I2C_CNT];     // If we are doing hardware I2C
+I2C_TypeDef *i2c_instance[DRV_I2C_CNT] = {I2C1, I2C2};
 
 int drv_i2c_init()
 {
+  for (int i=0; i < DRV_I2C_CNT; i++) 
+  {
+    drv_i2c_handles[i].Instance = i2c_instance[i];
+  }
   return 0;
 }
 
@@ -46,6 +51,13 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef *hi2c)
     GPIO_InitStruct.Pin       = GPIO_PIN_7;
     GPIO_InitStruct.Alternate = GPIO_AF4_I2C1;
     HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+
+    /* Peripheral interrupt init */
+    HAL_NVIC_SetPriority(I2C1_EV_IRQn, 8, 0);
+    HAL_NVIC_EnableIRQ  (I2C1_EV_IRQn);
+    HAL_NVIC_SetPriority(I2C1_ER_IRQn, 8, 0);
+    HAL_NVIC_EnableIRQ  (I2C1_ER_IRQn);
+
   }
   if( hi2c->Instance == I2C2 )
   {
@@ -70,6 +82,12 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef *hi2c)
     GPIO_InitStruct.Pin       = GPIO_PIN_11;
     GPIO_InitStruct.Alternate = GPIO_AF4_I2C2;
     HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+
+    /* Peripheral interrupt init */
+    HAL_NVIC_SetPriority(I2C2_EV_IRQn, 8, 0);
+    HAL_NVIC_EnableIRQ  (I2C2_EV_IRQn);
+    HAL_NVIC_SetPriority(I2C2_ER_IRQn, 8, 0);
+    HAL_NVIC_EnableIRQ  (I2C2_ER_IRQn);
   }
 }
 
@@ -94,6 +112,10 @@ void HAL_I2C_MspDeInit(I2C_HandleTypeDef *hi2c)
     HAL_GPIO_DeInit(GPIOB, GPIO_PIN_8);
     /* Configure I2C SDA as alternate function  */
     HAL_GPIO_DeInit(GPIOB, GPIO_PIN_7);
+
+    /* Peripheral interrupt Deinit*/
+    HAL_NVIC_DisableIRQ  (I2C1_EV_IRQn);
+    HAL_NVIC_DisableIRQ  (I2C1_ER_IRQn);
   }
   if( hi2c->Instance == I2C2 )
   {
@@ -106,5 +128,25 @@ void HAL_I2C_MspDeInit(I2C_HandleTypeDef *hi2c)
     HAL_GPIO_DeInit(GPIOB, GPIO_PIN_10);
     /* Configure I2C SDA as alternate function  */
     HAL_GPIO_DeInit(GPIOB, GPIO_PIN_11);
+
+    /* Peripheral interrupt Deinit*/
+    HAL_NVIC_DisableIRQ  (I2C2_EV_IRQn);
+    HAL_NVIC_DisableIRQ  (I2C2_ER_IRQn);
   }
+}
+
+void I2C1_EV_IRQHandler(void) {
+  HAL_I2C_EV_IRQHandler( &drv_i2c_handles[0]);
+}
+
+void I2C2_EV_IRQHandler(void)  {
+  HAL_I2C_EV_IRQHandler( &drv_i2c_handles[1]);
+}
+
+void I2C1_ER_IRQHandler(void) {
+  HAL_I2C_ER_IRQHandler( &drv_i2c_handles[0]);
+}
+
+void I2C2_ER_IRQHandler(void)  {
+  HAL_I2C_ER_IRQHandler( &drv_i2c_handles[1]);
 }

--- a/arduino/opencr_arduino/opencr/variants/OpenCR/hw/driver/drv_i2c.h
+++ b/arduino/opencr_arduino/opencr/variants/OpenCR/hw/driver/drv_i2c.h
@@ -20,9 +20,10 @@
 
 
 
+#define DRV_I2C_CNT 2
 
-
-
+extern I2C_HandleTypeDef drv_i2c_handles[DRV_I2C_CNT];     // If we are doing hardware I2C
+ 
 
 int drv_i2c_init();
 

--- a/arduino/opencr_arduino/opencr/variants/OpenCR/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_i2c.h
+++ b/arduino/opencr_arduino/opencr/variants/OpenCR/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_i2c.h
@@ -112,6 +112,7 @@ typedef enum
   HAL_I2C_STATE_SLAVE_BUSY_RX   = 0x42,  /*!< Slave Data Reception process is ongoing     */
   HAL_I2C_STATE_MEM_BUSY_TX     = 0x52,  /*!< Memory Data Transmission process is ongoing */
   HAL_I2C_STATE_MEM_BUSY_RX     = 0x62,  /*!< Memory Data Reception process is ongoing    */
+  HAL_I2C_STATE_SLAVE_BUSY_ADR  = 0x72,   /*!< Slave Data waiting for address match        */
   HAL_I2C_STATE_TIMEOUT         = 0x03,  /*!< Timeout state                               */
   HAL_I2C_STATE_ERROR           = 0x04   /*!< Reception process is ongoing                */
 }HAL_I2C_StateTypeDef;
@@ -407,6 +408,21 @@ typedef struct
   */
 #define __HAL_I2C_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->ICR = ((__FLAG__) & I2C_FLAG_MASK))
  
+#define __HAL_I2C_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->CR1 & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+
+/** @brief Set I2C flag 
+  * @param  __HANDLE__: specifies the I2C Handle.
+  * @param  __FLAG__: specifies the flag to set.
+  *        This parameter can be one of the following values:
+  *            @arg I2C_FLAG_TXE:      Transmit data register empty
+  *            @arg I2C_FLAG_TXIS:     Transmit interrupt status
+  *
+  * @retval None
+  */
+#define I2C_FLAG_SET_MASK  ((uint32_t)0x03)
+#define __HAL_I2C_SET_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->ISR) |= ((__FLAG__) & I2C_FLAG_SET_MASK))
+
+
 /** @brief  Enable the specified I2C peripheral.
   * @param  __HANDLE__: specifies the I2C Handle. 
   * @retval None
@@ -460,6 +476,7 @@ HAL_StatusTypeDef HAL_I2C_IsDeviceReady(I2C_HandleTypeDef *hi2c, uint16_t DevAdd
 HAL_StatusTypeDef HAL_I2C_Master_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_I2C_Master_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_I2C_Slave_Transmit_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Slave_Addr_IT(I2C_HandleTypeDef *hi2c);
 HAL_StatusTypeDef HAL_I2C_Slave_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_I2C_Mem_Write_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_I2C_Mem_Read_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
@@ -485,6 +502,7 @@ void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef *hi2c);
 void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef *hi2c);
 void HAL_I2C_SlaveTxCpltCallback(I2C_HandleTypeDef *hi2c);
 void HAL_I2C_SlaveRxCpltCallback(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_SlaveAddrCpltCallback(I2C_HandleTypeDef *hi2c);
 void HAL_I2C_MemTxCpltCallback(I2C_HandleTypeDef *hi2c);
 void HAL_I2C_MemRxCpltCallback(I2C_HandleTypeDef *hi2c);
 void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *hi2c);

--- a/arduino/opencr_arduino/opencr/variants/OpenCR/variant.h
+++ b/arduino/opencr_arduino/opencr/variants/OpenCR/variant.h
@@ -126,7 +126,7 @@ void setLedOff(uint8_t led_num);
 void setLedToggle(uint8_t led_num);
 
 
-#define WIRE_INTERFACES_COUNT       1
+#define WIRE_INTERFACES_COUNT       2
 #define SPI_INTERFACES_COUNT        2
 #define EXTI_COUNT                  10
 #define PINS_COUNT                  85


### PR DESCRIPTION
Make a version of Wire library that used hardware I2C objects.
This includes the default one that was using bitbang

As well as Wire1 which uses pins 50, 51 of expansion connector.

Also support hopefully for Wire Slave objects. 

This is the work that I have been doing as part of the issue:
https://github.com/ROBOTIS-GIT/OpenCR/issues/107

Thought it might make sense now to create it as a pull request, so you might be able to start reviewing it and or testing it out. 

Let me know if you would like any changes made. 

Thanks
Kurt
