### PR TITLE
Remove Compiler Warnings

### DIFF
--- a/arduino/opencr_arduino/opencr/libraries/EEPROM/src/EEPROM.h
+++ b/arduino/opencr_arduino/opencr/libraries/EEPROM/src/EEPROM.h
@@ -39,7 +39,7 @@ struct EERef{
 
     //Access/read members.
     uint8_t operator*() const            { return drv_eeprom_read_byte( index ); }
-    operator const uint8_t() const       { return **this; }
+    operator uint8_t() const       { return **this; }
 
     //Assignment/write members.
     EERef &operator=( const EERef &ref ) { return *this = *ref; }
@@ -88,7 +88,7 @@ struct EEPtr{
     EEPtr( const int index )
         : index( index )                {}
 
-    operator const int() const          { return index; }
+    operator int() const          { return index; }
     EEPtr &operator=( int in )          { return index = in, *this; }
 
     //Iterator functionality.
@@ -141,5 +141,5 @@ struct EEPROMClass{
     }
 };
 
-static EEPROMClass EEPROM;
+static EEPROMClass EEPROM __attribute__ ((unused));
 #endif


### PR DESCRIPTION
Removed extra const messages to match the Arduino 1.9.7 AVR version

Which removed several of the warning messages.

Added __attribute__((unused)) to the static EEPROMClss EEPROM statement like
The Teensy (PJRC) versions, which removed the other warnings

    eeprom_warning_msgs

Attempt2 - first one changed all of the line endings so look like I changed
the whole file