### PR TITLE
Workbench get servo info

### DIFF
--- a/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/include/dynamixel_workbench_toolbox/dynamixel_driver.h
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/include/dynamixel_workbench_toolbox/dynamixel_driver.h
@@ -39,13 +39,13 @@
 
 typedef struct 
 {
-  ControlTableItem *cti; 
+  const ControlTableItem *cti; 
   dynamixel::GroupSyncWrite *groupSyncWrite;    
 } SyncWriteHandler;
 
 typedef struct 
 {
-  ControlTableItem *cti;
+  const ControlTableItem *cti;
   dynamixel::GroupSyncRead  *groupSyncRead;     
 } SyncReadHandler;
 
@@ -84,7 +84,7 @@ class DynamixelDriver
   int getBaudrate(void);
   char* getModelName(uint8_t id);
   uint16_t getModelNum(uint8_t id);
-  ControlTableItem* getControlItemPtr(uint8_t id);
+  const ControlTableItem* getControlItemPtr(uint8_t id);
   uint8_t getTheNumberOfItem(uint8_t id);
 
   bool scan(uint8_t *get_id, uint8_t *get_id_num, uint8_t range = 200);

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/include/dynamixel_workbench_toolbox/dynamixel_item.h
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/include/dynamixel_workbench_toolbox/dynamixel_item.h
@@ -81,7 +81,7 @@ typedef struct
 } ModelInfo;
 
 uint8_t getTheNumberOfControlItem();
-ControlTableItem* getConrolTableItem(uint16_t model_number);
+const ControlTableItem* getConrolTableItem(uint16_t model_number);
 ModelInfo* getModelInfo(uint16_t model_number);
 
 #endif //DYNAMIXEL_H

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/include/dynamixel_workbench_toolbox/dynamixel_tool.h
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/include/dynamixel_workbench_toolbox/dynamixel_tool.h
@@ -23,12 +23,6 @@
 
 #include "dynamixel_item.h"
 
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  #define ITEM_ARRAY_SIZE 14
-#else
-  #define ITEM_ARRAY_SIZE 60
-#endif
-
 typedef struct
 {
   char model_name[20];
@@ -43,14 +37,8 @@ class DynamixelTool
   uint8_t dxl_info_cnt_;
 
  private:
-  ControlTableItem* item_ptr_;
+  const ControlTableItem* item_ptr_;
   ModelInfo* info_ptr_;
-
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  ControlTableItem item_[ITEM_ARRAY_SIZE];
-#else
-  ControlTableItem item_[ITEM_ARRAY_SIZE];
-#endif
 
   ModelInfo info_;
   uint8_t the_number_of_item_;
@@ -76,8 +64,8 @@ class DynamixelTool
   float getMaxRadian(void);
 
   uint8_t getTheNumberOfItem(void);
-  ControlTableItem* getControlItem(const char *item_name);
-  ControlTableItem* getControlItemPtr(void);
+  const ControlTableItem* getControlItem(const char *item_name);
+  const ControlTableItem* getControlItemPtr(void);
   ModelInfo* getModelInfoPtr(void);
 
  private:

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/include/dynamixel_workbench_toolbox/dynamixel_workbench.h
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/include/dynamixel_workbench_toolbox/dynamixel_workbench.h
@@ -102,6 +102,12 @@ class DynamixelWorkbench
   int16_t convertTorque2Value(uint8_t id, float torque);
   float convertValue2Torque(uint8_t id, int16_t value);
 
+  // Wish List... 
+  ControlTableItem* getControlItemPtr(uint8_t id);
+  uint8_t getTheNumberOfItem(uint8_t id);
+
+
+
  private:
   void millis(uint16_t msec);
 

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/include/dynamixel_workbench_toolbox/dynamixel_workbench.h
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/include/dynamixel_workbench_toolbox/dynamixel_workbench.h
@@ -103,8 +103,8 @@ class DynamixelWorkbench
   float convertValue2Torque(uint8_t id, int16_t value);
 
   // Wish List... 
-  ControlTableItem* getControlItemPtr(uint8_t id);
-  uint8_t getTheNumberOfItem(uint8_t id);
+  const ControlTableItem* getControlItemPtr(uint8_t id);
+  uint8_t getControlItemCount(uint8_t id);
 
 
 

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/keywords.txt
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/keywords.txt
@@ -45,6 +45,8 @@ convertVelocity2Value KEYWORD2
 convertValue2Velocity KEYWORD2
 convertTorque2Value   KEYWORD2
 convertValue2Torque   KEYWORD2
+getControlItemPtr	KEYWORD2
+getControlItemCount	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
@@ -411,6 +411,11 @@ bool DynamixelDriver::writeRegister(uint8_t id, const char *item_name, int32_t d
   const ControlTableItem *cti;
   cti = tools_[getToolsFactor(id)].getControlItem(item_name);
 
+  if (cti == NULL)
+  {
+    return false;
+  }
+
   if (cti->data_length == BYTE)
   {
     dxl_comm_result = packetHandler_->write1ByteTxRx(portHandler_, id, cti->address, (uint8_t)data, &error);
@@ -483,7 +488,11 @@ bool DynamixelDriver::readRegister(uint8_t id, const char *item_name, int32_t *d
 
   const ControlTableItem *cti;
   cti = tools_[getToolsFactor(id)].getControlItem(item_name);
-
+  if (cti == NULL)
+  {
+    return false;
+  }
+  
   if (cti->data_length == BYTE)
   {
     dxl_comm_result = packetHandler_->read1ByteTxRx(portHandler_, id, cti->address, (uint8_t *)&value_8_bit, &error);
@@ -705,6 +714,11 @@ void DynamixelDriver::addSyncWrite(const char *item_name)
   const ControlTableItem *cti;
   cti = tools_[0].getControlItem(item_name);
 
+  if (cti == NULL)
+  {
+    return;
+  }
+
   syncWriteHandler_[sync_write_handler_cnt_].cti = cti;
 
   syncWriteHandler_[sync_write_handler_cnt_++].groupSyncWrite = new dynamixel::GroupSyncWrite(portHandler_,
@@ -822,6 +836,10 @@ void DynamixelDriver::addSyncRead(const char *item_name)
   const ControlTableItem *cti;
   cti = tools_[0].getControlItem(item_name);
 
+  if (cti == NULL)
+  {
+    return;
+  }
   syncReadHandler_[sync_read_handler_cnt_].cti = cti;
   
   syncReadHandler_[sync_read_handler_cnt_++].groupSyncRead = new dynamixel::GroupSyncRead(portHandler_,
@@ -905,6 +923,10 @@ bool DynamixelDriver::addBulkWriteParam(uint8_t id, const char *item_name, int32
 
   const ControlTableItem *cti;
   cti = tools_[getToolsFactor(id)].getControlItem(item_name);
+  if (cti == NULL)
+  {
+    return false;
+  }
 
   data_byte[0] = DXL_LOBYTE(DXL_LOWORD(data));
   data_byte[1] = DXL_HIBYTE(DXL_LOWORD(data));
@@ -946,6 +968,10 @@ bool DynamixelDriver::addBulkReadParam(uint8_t id, const char *item_name)
 
   const ControlTableItem *cti;
   cti = tools_[getToolsFactor(id)].getControlItem(item_name);
+  if (cti == NULL)
+  {
+    return false;
+  }
 
   dxl_addparam_result = groupBulkRead_->addParam(id, cti->address, cti->data_length);
   if (dxl_addparam_result != true)
@@ -974,6 +1000,10 @@ bool DynamixelDriver::bulkRead(uint8_t id, const char *item_name, int32_t *data)
   bool dxl_getdata_result = false;
   const ControlTableItem *cti;
   cti = tools_[getToolsFactor(id)].getControlItem(item_name);
+  if (cti == NULL)
+  {
+    return false;
+  }
 
   dxl_getdata_result = groupBulkRead_->isAvailable(id, cti->address, cti->data_length);
   if (dxl_getdata_result != true)

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
@@ -164,7 +164,7 @@ uint16_t DynamixelDriver::getModelNum(uint8_t id)
   }
 }
 
-ControlTableItem* DynamixelDriver::getControlItemPtr(uint8_t id)
+const ControlTableItem* DynamixelDriver::getControlItemPtr(uint8_t id)
 {
   uint8_t factor = getToolsFactor(id);
 
@@ -405,7 +405,7 @@ bool DynamixelDriver::writeRegister(uint8_t id, const char *item_name, int32_t d
   uint8_t error = 0;
   int dxl_comm_result = COMM_TX_FAIL;
 
-  ControlTableItem *cti;
+  const ControlTableItem *cti;
   cti = tools_[getToolsFactor(id)].getControlItem(item_name);
 
   if (cti->data_length == BYTE)
@@ -478,7 +478,7 @@ bool DynamixelDriver::readRegister(uint8_t id, const char *item_name, int32_t *d
   int16_t value_16_bit = 0;
   int32_t value_32_bit = 0;
 
-  ControlTableItem *cti;
+  const ControlTableItem *cti;
   cti = tools_[getToolsFactor(id)].getControlItem(item_name);
 
   if (cti->data_length == BYTE)
@@ -698,7 +698,7 @@ const char *DynamixelDriver::findModelName(uint16_t model_num)
 
 void DynamixelDriver::addSyncWrite(const char *item_name)
 {
-  ControlTableItem *cti;
+  const ControlTableItem *cti;
   cti = tools_[0].getControlItem(item_name);
 
   syncWriteHandler_[sync_write_handler_cnt_].cti = cti;
@@ -799,7 +799,7 @@ bool DynamixelDriver::syncWrite(uint8_t *id, uint8_t id_num, const char *item_na
 
 void DynamixelDriver::addSyncRead(const char *item_name)
 {
-  ControlTableItem *cti;
+  const ControlTableItem *cti;
   cti = tools_[0].getControlItem(item_name);
 
   syncReadHandler_[sync_read_handler_cnt_].cti = cti;
@@ -877,7 +877,7 @@ bool DynamixelDriver::addBulkWriteParam(uint8_t id, const char *item_name, int32
   bool dxl_addparam_result = false;
   uint8_t data_byte[4] = {0, };
 
-  ControlTableItem *cti;
+  const ControlTableItem *cti;
   cti = tools_[getToolsFactor(id)].getControlItem(item_name);
 
   data_byte[0] = DXL_LOBYTE(DXL_LOWORD(data));
@@ -918,7 +918,7 @@ bool DynamixelDriver::addBulkReadParam(uint8_t id, const char *item_name)
 {
   bool dxl_addparam_result = false;
 
-  ControlTableItem *cti;
+  const ControlTableItem *cti;
   cti = tools_[getToolsFactor(id)].getControlItem(item_name);
 
   dxl_addparam_result = groupBulkRead_->addParam(id, cti->address, cti->data_length);
@@ -946,7 +946,7 @@ bool DynamixelDriver::sendBulkReadPacket()
 bool DynamixelDriver::bulkRead(uint8_t id, const char *item_name, int32_t *data)
 {
   bool dxl_getdata_result = false;
-  ControlTableItem *cti;
+  const ControlTableItem *cti;
   cti = tools_[getToolsFactor(id)].getControlItem(item_name);
 
   dxl_getdata_result = groupBulkRead_->isAvailable(id, cti->address, cti->data_length);

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
@@ -151,6 +151,7 @@ char *DynamixelDriver::getModelName(uint8_t id)
     if (tools_[factor].dxl_info_[i].id == id)
       return tools_[factor].dxl_info_[i].model_name;
   }
+  return NULL;
 }
 
 uint16_t DynamixelDriver::getModelNum(uint8_t id)
@@ -162,6 +163,7 @@ uint16_t DynamixelDriver::getModelNum(uint8_t id)
     if (tools_[factor].dxl_info_[i].id == id)
       return tools_[factor].dxl_info_[i].model_num;
   }
+  return 0;
 }
 
 const ControlTableItem* DynamixelDriver::getControlItemPtr(uint8_t id)
@@ -398,6 +400,7 @@ bool DynamixelDriver::reset(uint8_t id)
       return false;
     }
   }
+  return false;  // should never get here.
 }
 
 bool DynamixelDriver::writeRegister(uint8_t id, const char *item_name, int32_t data)
@@ -606,6 +609,7 @@ uint8_t DynamixelDriver::getToolsFactor(uint8_t id)
       }
     }
   }
+  return 0;   // BUGBUG:: Not sure what a good last resort value is
 }
 
 const char *DynamixelDriver::findModelName(uint16_t model_num)
@@ -718,13 +722,21 @@ bool DynamixelDriver::syncWrite(const char *item_name, int32_t *data)
   uint8_t cnt = 0;
 
   SyncWriteHandler swh;
+  bool swh_found = false;
 
   for (int index = 0; index < sync_write_handler_cnt_; index++)
   {
     if (!strncmp(syncWriteHandler_[index].cti->item_name, item_name, strlen(item_name)))
     {
       swh = syncWriteHandler_[index];
+      swh_found = true;
+      break;
     }
+  }
+
+  if (!swh_found)
+  {
+    return false;
   }
 
   for (int i = 0; i < tools_cnt_; i++)
@@ -764,15 +776,23 @@ bool DynamixelDriver::syncWrite(uint8_t *id, uint8_t id_num, const char *item_na
   uint8_t cnt = 0;
 
   SyncWriteHandler swh;
+  bool swh_found = false;
 
   for (int index = 0; index < sync_write_handler_cnt_; index++)
   {
     if (!strncmp(syncWriteHandler_[index].cti->item_name, item_name, strlen(item_name)))
     {
       swh = syncWriteHandler_[index];
+      swh_found = true;
+      break;
     }
   }
 
+  if (!swh_found)
+  {
+    return false;
+  }
+  
   for (int i = 0; i < id_num; i++)
   {
     data_byte[0] = DXL_LOBYTE(DXL_LOWORD(data[cnt]));
@@ -819,15 +839,21 @@ bool DynamixelDriver::syncRead(const char *item_name, int32_t *data)
   int index = 0;
 
   SyncReadHandler srh;
+  bool srh_found = false;
   
   for (int index = 0; index < sync_read_handler_cnt_; index++)
   {
     if (!strncmp(syncReadHandler_[index].cti->item_name, item_name, strlen(item_name)))
     {
       srh = syncReadHandler_[index];
+      srh_found = true;
+      break; // Found it, don't need to continue search
     }
   }
-
+  if (!srh_found)
+  {
+    return false; // did not find item_name in list
+  }
   for (int i = 0; i < tools_cnt_; i++)
   {
     for (int j = 0; j < tools_[i].dxl_info_cnt_; j++)

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/src/dynamixel_workbench_toolbox/dynamixel_item.cpp
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/src/dynamixel_workbench_toolbox/dynamixel_item.cpp
@@ -20,7 +20,7 @@
 static uint8_t the_number_of_item = 0;
 
 
-static ModelInfo model_info = {0.0, };
+static ModelInfo model_info = {0.0, 0.0, 0, 0, 0, 0.0, 0.0};
 
 //=========================================================
 // Servo register definitions

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/src/dynamixel_workbench_toolbox/dynamixel_item.cpp
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/src/dynamixel_workbench_toolbox/dynamixel_item.cpp
@@ -17,74 +17,53 @@
 /* Authors: Taehun Lim (Darby) */
 
 #include "../../include/dynamixel_workbench_toolbox/dynamixel_item.h"
-
 static uint8_t the_number_of_item = 0;
 
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-static ControlTableItem item[15]  = {0, };
-#else
-static ControlTableItem item[60]  = {0, };
-#endif
 
 static ModelInfo model_info = {0.0, };
 
-static void setAXItem(void)
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {3  , "ID"                            , 1};
-  item[1]  = {4  , "Baud_Rate"                     , 1};
-  item[2]  = {6  , "CW_Angle_Limit"                , 2};
-  item[3]  = {8  , "CCW_Angle_Limit"               , 2};
+//=========================================================
+// Servo register definitions
+//=========================================================
 
-  item[4]  = {24 , "Torque_Enable"                 , 1};
-  item[5]  = {25 , "LED"                           , 1};
-  item[6]  = {30 , "Goal_Position"                 , 2};
-  item[7]  = {32 , "Moving_Speed"                  , 2};
-  item[8]  = {34 , "Torque_Limit"                  , 2};
-  item[9]  = {36 , "Present_Position"              , 2};
-  item[10] = {38 , "Present_Speed"                 , 2};
-  item[11] = {40 , "Present_Load"                  , 2};
-  item[12] = {46 , "Moving"                        , 1};
+//---------------------------------------------------------
+// AX servos - (num == AX_12A || num == AX_12W || num == AX_18A)
+//---------------------------------------------------------
+static const ControlTableItem items_AX[] {
+    {0  , "Model_Number"                  , 2},
+    {2  , "Firmware_Version"              , 1},
+    {3  , "ID"                            , 1},
+    {4  , "Baud_Rate"                     , 1},
+    {5  , "Return_Delay_Time"             , 1},
+    {6  , "CW_Angle_Limit"                , 2},
+    {8  , "CCW_Angle_Limit"               , 2},
+    {11 , "Temperature_Limit"             , 1},
+    {12 , "Min_Voltage_Limit"             , 1},
+    {13 , "Max_Voltage_Limit"             , 1},
+    {14 , "Max_Torque"                    , 2},
+    {16 , "Status_Return_Level"           , 1},
+    {17 , "Alarm_LED"                     , 1},
+    {18 , "Shutdown"                      , 1},
 
-  the_number_of_item = 13;
-#else
-  item[0]  = {0  , "Model_Number"                  , 2};
-  item[1]  = {2  , "Firmware_Version"              , 1};
-  item[2]  = {3  , "ID"                            , 1};
-  item[3]  = {4  , "Baud_Rate"                     , 1};
-  item[4]  = {5  , "Return_Delay_Time"             , 1};
-  item[5]  = {6  , "CW_Angle_Limit"                , 2};
-  item[6]  = {8  , "CCW_Angle_Limit"               , 2};
-  item[7]  = {11 , "Temperature_Limit"             , 1};
-  item[8]  = {12 , "Min_Voltage_Limit"             , 1};
-  item[9]  = {13 , "Max_Voltage_Limit"             , 1};
-  item[10] = {14 , "Max_Torque"                    , 2};
-  item[11] = {16 , "Status_Return_Level"           , 1};
-  item[12] = {17 , "Alarm_LED"                     , 1};
-  item[13] = {18 , "Shutdown"                      , 1};
-
-  item[14] = {24 , "Torque_Enable"                 , 1};
-  item[15] = {25 , "LED"                           , 1};
-  item[16] = {26 , "CW_Compliance_Margin"          , 1};
-  item[17] = {27 , "CCW_Compliance_Margin"         , 1};
-  item[18] = {28 , "CW_Compliance_Slope"           , 1};
-  item[19] = {29 , "CCW_Compliance_Slope"          , 1};
-  item[20] = {30 , "Goal_Position"                 , 2};
-  item[21] = {32 , "Moving_Speed"                  , 2};
-  item[22] = {34 , "Torque_Limit"                  , 2};
-  item[23] = {36 , "Present_Position"              , 2};
-  item[24] = {38 , "Present_Speed"                 , 2};
-  item[25] = {40 , "Present_Load"                  , 2};
-  item[26] = {42 , "Present_Voltage"               , 1};
-  item[27] = {43 , "Present_Temperature"           , 1};
-  item[28] = {44 , "Registered"                    , 1};
-  item[29] = {46 , "Moving"                        , 1};
-  item[30] = {47 , "Lock"                          , 1};
-  item[31] = {48 , "Punch"                         , 2};
-
-  the_number_of_item = 32;
-#endif  
-}
+    {24 , "Torque_Enable"                 , 1},
+    {25 , "LED"                           , 1},
+    {26 , "CW_Compliance_Margin"          , 1},
+    {27 , "CCW_Compliance_Margin"         , 1},
+    {28 , "CW_Compliance_Slope"           , 1},
+    {29 , "CCW_Compliance_Slope"          , 1},
+    {30 , "Goal_Position"                 , 2},
+    {32 , "Moving_Speed"                  , 2},
+    {34 , "Torque_Limit"                  , 2},
+    {36 , "Present_Position"              , 2},
+    {38 , "Present_Speed"                 , 2},
+    {40 , "Present_Load"                  , 2},
+    {42 , "Present_Voltage"               , 1},
+    {43 , "Present_Temperature"           , 1},
+    {44 , "Registered"                    , 1},
+    {46 , "Moving"                        , 1},
+    {47 , "Lock"                          , 1},
+    {48 , "Punch"                         , 2} };
+#define COUNT_AX_ITEMS (sizeof(items_AX)/sizeof(items_AX[0]))
 
 static void setAXInfo()
 {
@@ -98,63 +77,45 @@ static void setAXInfo()
   model_info.max_radian                      =  2.61799;
 }
 
-static void setRXItem()
-{
-  #if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {3  , "ID"                            , 1};
-  item[1]  = {4  , "Baud_Rate"                     , 1};
-  item[2]  = {6  , "CW_Angle_Limit"                , 2};
-  item[3]  = {8  , "CCW_Angle_Limit"               , 2};
+//---------------------------------------------------------
+// RX servos - (num == RX_10 || num == RX_24F || num == RX_28 || num == RX_64)
+//---------------------------------------------------------
+static const ControlTableItem items_RX[] {
+    {0  , "Model_Number"                  , 2},
+    {2  , "Firmware_Version"              , 1},
+    {3  , "ID"                            , 1},
+    {4  , "Baud_Rate"                     , 1},
+    {5  , "Return_Delay_Time"             , 1},
+    {6  , "CW_Angle_Limit"                , 2},
+    {8  , "CCW_Angle_Limit"               , 2},
+    {11 , "Temperature_Limit"             , 1},
+    {12 , "Min_Voltage_Limit"             , 1},
+    {13 , "Max_Voltage_Limit"             , 1},
+    {14 , "Max_Torque"                    , 2},
+    {16 , "Status_Return_Level"           , 1},
+    {17 , "Alarm_LED"                     , 1},
+    {18 , "Shutdown"                      , 1},
 
-  item[4]  = {24 , "Torque_Enable"                 , 1};
-  item[5]  = {25 , "LED"                           , 1};
-  item[6]  = {30 , "Goal_Position"                 , 2};
-  item[7]  = {32 , "Moving_Speed"                  , 2};
-  item[8]  = {34 , "Torque_Limit"                  , 2};
-  item[9]  = {36 , "Present_Position"              , 2};
-  item[10] = {38 , "Present_Speed"                 , 2};
-  item[11] = {40 , "Present_Load"                  , 2};
-  item[12] = {46 , "Moving"                        , 1};
+    {24 , "Torque_Enable"                 , 1},
+    {25 , "LED"                           , 1},
+    {26 , "CW_Compliance_Margin"          , 1},
+    {27 , "CCW_Compliance_Margin"         , 1},
+    {28 , "CW_Compliance_Slope"           , 1},
+    {29 , "CCW_Compliance_Slope"          , 1},
+    {30 , "Goal_Position"                 , 2},
+    {32 , "Moving_Speed"                  , 2},
+    {34 , "Torque_Limit"                  , 2},
+    {36 , "Present_Position"              , 2},
+    {38 , "Present_Speed"                 , 2},
+    {40 , "Present_Load"                  , 2},
+    {42 , "Present_Voltage"               , 1},
+    {43 , "Present_Temperature"           , 1},
+    {44 , "Registered"                    , 1},
+    {46 , "Moving"                        , 1},
+    {47 , "Lock"                          , 1},
+    {48 , "Punch"                         , 2} };
 
-  the_number_of_item = 13;
-#else
-  item[0]  = {0  , "Model_Number"                  , 2};
-  item[1]  = {2  , "Firmware_Version"              , 1};
-  item[2]  = {3  , "ID"                            , 1};
-  item[3]  = {4  , "Baud_Rate"                     , 1};
-  item[4]  = {5  , "Return_Delay_Time"             , 1};
-  item[5]  = {6  , "CW_Angle_Limit"                , 2};
-  item[6]  = {8  , "CCW_Angle_Limit"               , 2};
-  item[7]  = {11 , "Temperature_Limit"             , 1};
-  item[8]  = {12 , "Min_Voltage_Limit"             , 1};
-  item[9]  = {13 , "Max_Voltage_Limit"             , 1};
-  item[10] = {14 , "Max_Torque"                    , 2};
-  item[11] = {16 , "Status_Return_Level"           , 1};
-  item[12] = {17 , "Alarm_LED"                     , 1};
-  item[13] = {18 , "Shutdown"                      , 1};
-
-  item[14] = {24 , "Torque_Enable"                 , 1};
-  item[15] = {25 , "LED"                           , 1};
-  item[16] = {26 , "CW_Compliance_Margin"          , 1};
-  item[17] = {27 , "CCW_Compliance_Margin"         , 1};
-  item[18] = {28 , "CW_Compliance_Slope"           , 1};
-  item[19] = {29 , "CCW_Compliance_Slope"          , 1};
-  item[20] = {30 , "Goal_Position"                 , 2};
-  item[21] = {32 , "Moving_Speed"                  , 2};
-  item[22] = {34 , "Torque_Limit"                  , 2};
-  item[23] = {36 , "Present_Position"              , 2};
-  item[24] = {38 , "Present_Speed"                 , 2};
-  item[25] = {40 , "Present_Load"                  , 2};
-  item[26] = {42 , "Present_Voltage"               , 1};
-  item[27] = {43 , "Present_Temperature"           , 1};
-  item[28] = {44 , "Registered"                    , 1};
-  item[29] = {46 , "Moving"                        , 1};
-  item[30] = {47 , "Lock"                          , 1};
-  item[31] = {48 , "Punch"                         , 2};
-
-  the_number_of_item = 32;
-#endif  
-}
+#define COUNT_RX_ITEMS (sizeof(items_RX)/sizeof(items_RX[0]))
 
 static void setRXInfo(void)
 {
@@ -168,66 +129,47 @@ static void setRXInfo(void)
   model_info.max_radian                      =  2.61799;
 }
 
-static void setEXItem()
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {3  , "ID"                            , 1};
-  item[1]  = {4  , "Baud_Rate"                     , 1};
-  item[2]  = {6  , "CW Angle_Limit"                , 2};
-  item[3]  = {8  , "CCW Angle_Limit"               , 2};
-  item[4]  = {10 , "Drive_Mode"                    , 1};
+//---------------------------------------------------------
+// EX servos - (num == EX_106)
+//---------------------------------------------------------
+static const ControlTableItem items_EX[] {
+    {0  , "Model_Number"                  , 2},
+    {2  , "Firmware_Version"              , 1},
+    {3  , "ID"                            , 1},
+    {4  , "Baud_Rate"                     , 1},
+    {5  , "Return_Delay_Time"             , 1},
+    {6  , "CW_Angle_Limit"                , 2},
+    {8  , "CCW_Angle_Limit"               , 2},
+    {10 , "Drive_Mode"                    , 1},
+    {11 , "Temperature_Limit"             , 1},
+    {12 , "Min_Voltage_Limit"             , 1},
+    {13 , "Max_Voltage_Limit"             , 1},
+    {14 , "Max_Torque"                    , 2},
+    {16 , "Status_Return_Level"           , 1},
+    {17 , "Alarm_LED"                     , 1},
+    {18 , "Shutdown"                      , 1},
 
-  item[5]  = {24 , "Torque_Enable"                 , 1};
-  item[6]  = {25 , "LED"                           , 1};
-  item[7]  = {30 , "Goal_Position"                 , 2};
-  item[8]  = {32 , "Moving_Speed"                  , 2};
-  item[9]  = {34 , "Torque_Limit"                  , 2};
-  item[10] = {36 , "Present_Position"              , 2};
-  item[11] = {38 , "Present_Speed"                 , 2};
-  item[12] = {40 , "Present_Load"                  , 2};
-  item[13] = {46 , "Moving"                        , 1};
+    {24 , "Torque_Enable"                 , 1},
+    {25 , "LED"                           , 1},
+    {26 , "CW_Compliance_Margin"          , 1},
+    {27 , "CCW_Compliance_Margin"         , 1},
+    {28 , "CW_Compliance_Slope"           , 1},
+    {29 , "CCW_Compliance_Slope"          , 1},
+    {30 , "Goal_Position"                 , 2},
+    {34 , "Moving_Speed"                  , 2},
+    {35 , "Torque_Limit"                  , 2},
+    {36 , "Present_Position"              , 2},
+    {38 , "Present_Speed"                 , 2},
+    {40 , "Present_Load"                  , 2},
+    {42 , "Present_Voltage"               , 1},
+    {43 , "Present_Temperature"           , 1},
+    {44 , "Registered"                    , 1},
+    {46 , "Moving"                        , 1},
+    {47 , "Lock"                          , 1},
+    {48 , "Punch"                         , 2},
+    {56 , "Sensored_Current"              , 2} };
 
-  the_number_of_item = 14;
-#else
-  item[0]  = {0  , "Model_Number"                  , 2};
-  item[1]  = {2  , "Firmware_Version"              , 1};
-  item[2]  = {3  , "ID"                            , 1};
-  item[3]  = {4  , "Baud_Rate"                     , 1};
-  item[4]  = {5  , "Return_Delay_Time"             , 1};
-  item[5]  = {6  , "CW_Angle_Limit"                , 2};
-  item[6]  = {8  , "CCW_Angle_Limit"               , 2};
-  item[7]  = {10 , "Drive_Mode"                    , 1};
-  item[8]  = {11 , "Temperature_Limit"             , 1};
-  item[9]  = {12 , "Min_Voltage_Limit"             , 1};
-  item[10] = {13 , "Max_Voltage_Limit"             , 1};
-  item[11] = {14 , "Max_Torque"                    , 2};
-  item[12] = {16 , "Status_Return_Level"           , 1};
-  item[13] = {17 , "Alarm_LED"                     , 1};
-  item[14] = {18 , "Shutdown"                      , 1};
-
-  item[15] = {24 , "Torque_Enable"                 , 1};
-  item[16] = {25 , "LED"                           , 1};
-  item[17] = {26 , "CW_Compliance_Margin"          , 1};
-  item[18] = {27 , "CCW_Compliance_Margin"         , 1};
-  item[19] = {28 , "CW_Compliance_Slope"           , 1};
-  item[20] = {29 , "CCW_Compliance_Slope"          , 1};
-  item[21] = {30 , "Goal_Position"                 , 2};
-  item[22] = {34 , "Moving_Speed"                  , 2};
-  item[23] = {35 , "Torque_Limit"                  , 2};
-  item[24] = {36 , "Present_Position"              , 2};
-  item[25] = {38 , "Present_Speed"                 , 2};
-  item[26] = {40 , "Present_Load"                  , 2};
-  item[27] = {42 , "Present_Voltage"               , 1};
-  item[28] = {43 , "Present_Temperature"           , 1};
-  item[29] = {44 , "Registered"                    , 1};
-  item[30] = {46 , "Moving"                        , 1};
-  item[31] = {47 , "Lock"                          , 1};
-  item[32] = {48 , "Punch"                         , 2};
-  item[33] = {56 , "Sensored_Current"              , 2};
-
-  the_number_of_item = 34;
-#endif  
-}
+#define COUNT_EX_ITEMS (sizeof(items_EX)/sizeof(items_EX[0]))
 
 static void setEXInfo()
 {
@@ -241,66 +183,47 @@ static void setEXInfo()
   model_info.max_radian                      =  2.18969008;
 }
 
-static void setMXItem()
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {3  , "ID"                            , 1};
-  item[1]  = {4  , "Baud_Rate"                     , 1};
-  item[2]  = {6  , "CW_Angle_Limit"                , 2};
-  item[3]  = {8  , "CCW_Angle_Limit"               , 2};
+//---------------------------------------------------------
+// MX Protocol 1 servos - (num == MX_12W || num == MX_28)
+//---------------------------------------------------------
+static const ControlTableItem items_MX[] {
+    {0  , "Model_Number"                  , 2},
+    {2  , "Firmware_Version"              , 1},
+    {3  , "ID"                            , 1},
+    {4  , "Baud_Rate"                     , 1},
+    {5  , "Return_Delay_Time"             , 1},
+    {6  , "CW_Angle_Limit"                , 2},
+    {8  , "CCW_Angle_Limit"               , 2},
+    {11 , "Temperature_Limit"             , 1},
+    {12 , "Min_Voltage_Limit"             , 1},
+    {13 , "Max_Voltage_Limit"             , 1},
+    {14 , "Max_Torque"                    , 2},
+    {16 , "Status_Return_Level"           , 1},
+    {17 , "Alarm_LED"                     , 1},
+    {18 , "Shutdown"                      , 1},
+    {20 , "Multi_Turn_Offset"             , 2},
+    {22 , "Resolution_Divider"            , 1},
 
-  item[4]  = {24 , "Torque_Enable"                 , 1};
-  item[5]  = {25 , "LED"                           , 1};
-  item[6]  = {30 , "Goal_Position"                 , 2};
-  item[7]  = {32 , "Moving_Speed"                  , 2};
-  item[8]  = {34 , "Torque_Limit"                  , 2};
-  item[9]  = {36 , "Present_Position"              , 2};
-  item[10] = {38 , "Present_Speed"                 , 2};
-  item[11] = {40 , "Present_Load"                  , 2};
-  item[12] = {46 , "Moving"                        , 1};
-  item[13] = {73 , "Goal_Acceleration"             , 1};
+    {24 , "Torque_Enable"                 , 1},
+    {25 , "LED"                           , 1},
+    {26 , "D_gain"                        , 1},
+    {27 , "I_gain"                        , 1},
+    {28 , "P_gain"                        , 1},
+    {30 , "Goal_Position"                 , 2},
+    {32 , "Moving_Speed"                  , 2},
+    {34 , "Torque_Limit"                  , 2},
+    {36 , "Present_Position"              , 2},
+    {38 , "Present_Speed"                 , 2},
+    {40 , "Present_Load"                  , 2},
+    {42 , "Present_Voltage"               , 1},
+    {43 , "Present_Temperature"           , 1},
+    {44 , "Registered"                    , 1},
+    {46 , "Moving"                        , 1},
+    {47 , "Lock"                          , 1},
+    {48 , "Punch"                         , 2},
+    {73 , "Goal_Acceleration"             , 1} };
 
-  the_number_of_item = 14;
-#else
-  item[0]  = {0  , "Model_Number"                  , 2};
-  item[1]  = {2  , "Firmware_Version"              , 1};
-  item[2]  = {3  , "ID"                            , 1};
-  item[3]  = {4  , "Baud_Rate"                     , 1};
-  item[4]  = {5  , "Return_Delay_Time"             , 1};
-  item[5]  = {6  , "CW_Angle_Limit"                , 2};
-  item[6]  = {8  , "CCW_Angle_Limit"               , 2};
-  item[7]  = {11 , "Temperature_Limit"             , 1};
-  item[8]  = {12 , "Min_Voltage_Limit"             , 1};
-  item[9]  = {13 , "Max_Voltage_Limit"             , 1};
-  item[10] = {14 , "Max_Torque"                    , 2};
-  item[11] = {16 , "Status_Return_Level"           , 1};
-  item[12] = {17 , "Alarm_LED"                     , 1};
-  item[13] = {18 , "Shutdown"                      , 1};
-  item[14] = {20 , "Multi_Turn_Offset"             , 2};
-  item[15] = {22 , "Resolution_Divider"            , 1};
-
-  item[16] = {24 , "Torque_Enable"                 , 1};
-  item[17] = {25 , "LED"                           , 1};
-  item[18] = {26 , "D_gain"                        , 1};
-  item[19] = {27 , "I_gain"                        , 1};
-  item[20] = {28 , "P_gain"                        , 1};
-  item[21] = {30 , "Goal_Position"                 , 2};
-  item[22] = {32 , "Moving_Speed"                  , 2};
-  item[23] = {34 , "Torque_Limit"                  , 2};
-  item[24] = {36 , "Present_Position"              , 2};
-  item[25] = {38 , "Present_Speed"                 , 2};
-  item[26] = {40 , "Present_Load"                  , 2};
-  item[27] = {42 , "Present_Voltage"               , 1};
-  item[28] = {43 , "Present_Temperature"           , 1};
-  item[29] = {44 , "Registered"                    , 1};
-  item[30] = {46 , "Moving"                        , 1};
-  item[31] = {47 , "Lock"                          , 1};
-  item[32] = {48 , "Punch"                         , 2};
-  item[33] = {73 , "Goal_Acceleration"             , 1};
-
-  the_number_of_item = 34;
-#endif  
-}
+#define COUNT_MX_ITEMS (sizeof(items_MX)/sizeof(items_MX[0]))
 
 static void setMXInfo()
 {
@@ -314,81 +237,63 @@ static void setMXInfo()
   model_info.max_radian                      =  3.14159265;
 }
 
-static void setMX2Item(void)
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {7  , "ID"                    , 1};
-  item[1]  = {8  , "Baud_Rate"             , 1};
-  item[2]  = {10 , "Drive_Mode"            , 1};
-  item[3]  = {11 , "Operating_Mode"        , 1};
+//---------------------------------------------------------
+// MX Protocol 2 servos - (num == MX_28_2)
+//---------------------------------------------------------
+static const ControlTableItem items_MX2[] {
+      {0  , "Model_Number"          , 2},
+      {6  , "Firmware_Version"      , 1},
+      {7  , "ID"                    , 1},
+      {8  , "Baud_Rate"             , 1},
+      {9  , "Return_Delay_Time"     , 1},
+      {10 , "Drive_Mode"            , 1},
+      {11 , "Operating_Mode"        , 1},
+      {12 , "Secondary_ID"          , 1},
+      {13 , "Protocol_Version"      , 1},
+      {20 , "Homing_Offset"         , 4},
+      {24 , "Moving_Threshold"      , 4},
+      {31 , "Temperature_Limit"     , 1},
+      {32 , "Max_Voltage_Limit"     , 2},
+      {34 , "Min_Voltage_Limit"     , 2},
+      {36 , "PWM_Limit"             , 2},
+      {40 , "Acceleration_Limit"    , 4},
+      {44 , "Velocity_Limit"        , 4},
+      {48 , "Max_Position_Limit"    , 4},
+      {52 , "Min_Position_Limit"    , 4},
+      {63 , "Shutdown"              , 1},
 
-  item[4]  = {64 , "Torque_Enable"         , 1};
-  item[5]  = {65 , "LED"                   , 1};
-  item[6]  = {104, "Goal_Velocity"         , 4};
-  item[7]  = {108, "Profile_Acceleration"  , 4};
-  item[8]  = {112, "Profile_Velocity"      , 4};
-  item[9]  = {116, "Goal_Position"         , 4};
-  item[10] = {122, "Moving"                , 1};
-  item[11] = {126, "Present_Load"          , 2};
-  item[12] = {128, "Present_Velocity"      , 4};
-  item[13] = {132, "Present_Position"      , 4};
+      {64 , "Torque_Enable"         , 1},
+      {65 , "LED"                   , 1},
+      {68 , "Status_Return_Level"   , 1},
+      {69 , "Registered_Instruction", 1},
+      {70 , "Hardware_Error_Status" , 1},
+      {76 , "Velocity_I_Gain"       , 2},
+      {78 , "Velocity_P_Gain"       , 2},
+      {80 , "Position_D_Gain"       , 2},
+      {82 , "Position_I_Gain"       , 2},
+      {84 , "Position_P_Gain"       , 2},
+      {88 , "Feedforward_2nd_Gain"  , 2},
+      {90 , "Feedforward_1st_Gain"  , 2},
+      {98 , "Bus_Watchdog"          , 1},
+      {100, "Goal_PWM"              , 2},
+      {104, "Goal_Velocity"         , 4},
+      {108, "Profile_Acceleration"  , 4},
+      {112, "Profile_Velocity"      , 4},
+      {116, "Goal_Position"         , 4},
+      {120, "Realtime_Tick"         , 2},
+      {122, "Moving"                , 1},
+      {123, "Moving_Status"         , 1},
+      {124, "Present_PWM"           , 2},
+      {126, "Present_Load"          , 2},
+      {128, "Present_Velocity"      , 4},
+      {132, "Present_Position"      , 4},
+      {136, "Velocity_Trajectory"   , 4},
+      {140, "Position_Trajectory"   , 4},
+      {144, "Present_Input_Voltage" , 2},
+      {146, "Present_Temperature"   , 1} };
 
-  the_number_of_item = 14;
-#else
-  item[0]  = {0  , "Model_Number"          , 2};
-  item[1]  = {6  , "Firmware_Version"      , 1};
-  item[2]  = {7  , "ID"                    , 1};
-  item[3]  = {8  , "Baud_Rate"             , 1};
-  item[4]  = {9  , "Return_Delay_Time"     , 1};
-  item[5]  = {10 , "Drive_Mode"            , 1};
-  item[6]  = {11 , "Operating_Mode"        , 1};
-  item[7]  = {12 , "Secondary_ID"          , 1};
-  item[8]  = {13 , "Protocol_Version"      , 1};
-  item[9]  = {20 , "Homing_Offset"         , 4};
-  item[10] = {24 , "Moving_Threshold"      , 4};
-  item[11] = {31 , "Temperature_Limit"     , 1};
-  item[12] = {32 , "Max_Voltage_Limit"     , 2};
-  item[13] = {34 , "Min_Voltage_Limit"     , 2};
-  item[14] = {36 , "PWM_Limit"             , 2};
-  item[15] = {40 , "Acceleration_Limit"    , 4};
-  item[16] = {44 , "Velocity_Limit"        , 4};
-  item[17] = {48 , "Max_Position_Limit"    , 4};
-  item[18] = {52 , "Min_Position_Limit"    , 4};
-  item[19] = {63 , "Shutdown"              , 1};
+#define COUNT_MX2_ITEMS (sizeof(items_MX2)/sizeof(items_MX2[0]))
 
-  item[20] = {64 , "Torque_Enable"         , 1};
-  item[21] = {65 , "LED"                   , 1};
-  item[22] = {68 , "Status_Return_Level"   , 1};
-  item[23] = {69 , "Registered_Instruction", 1};
-  item[24] = {70 , "Hardware_Error_Status" , 1};
-  item[25] = {76 , "Velocity_I_Gain"       , 2};
-  item[26] = {78 , "Velocity_P_Gain"       , 2};
-  item[27] = {80 , "Position_D_Gain"       , 2};
-  item[28] = {82 , "Position_I_Gain"       , 2};
-  item[29] = {84 , "Position_P_Gain"       , 2};
-  item[30] = {88 , "Feedforward_2nd_Gain"  , 2};
-  item[31] = {90 , "Feedforward_1st_Gain"  , 2};
-  item[32] = {98 , "Bus_Watchdog"          , 1};
-  item[33] = {100, "Goal_PWM"              , 2};
-  item[34] = {104, "Goal_Velocity"         , 4};
-  item[35] = {108, "Profile_Acceleration"  , 4};
-  item[36] = {112, "Profile_Velocity"      , 4};
-  item[37] = {116, "Goal_Position"         , 4};
-  item[38] = {120, "Realtime_Tick"         , 2};
-  item[39] = {122, "Moving"                , 1};
-  item[40] = {123, "Moving_Status"         , 1};
-  item[41] = {124, "Present_PWM"           , 2};
-  item[42] = {126, "Present_Load"          , 2};
-  item[43] = {128, "Present_Velocity"      , 4};
-  item[44] = {132, "Present_Position"      , 4};
-  item[45] = {136, "Velocity_Trajectory"   , 4};
-  item[46] = {140, "Position_Trajectory"   , 4};
-  item[47] = {144, "Present_Input_Voltage" , 2};
-  item[48] = {146, "Present_Temperature"   , 1};
-
-  the_number_of_item = 49;
-#endif  
-}
 
 static void setMX2Info(void)
 {
@@ -402,72 +307,50 @@ static void setMX2Info(void)
   model_info.max_radian                      =  3.14159265;
 }
 
-static void setExtMXItem()
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {3  , "ID"                            , 1};
-  item[1]  = {4  , "Baud_Rate"                     , 1};
-  item[2]  = {6  , "CW_Angle_Limit"                , 2};
-  item[3]  = {8  , "CCW_Angle_Limit"               , 2};
+//---------------------------------------------------------
+// EXT MX Protocol 1 servos - (num == MX_64 || num == MX_106)
+//---------------------------------------------------------
+static const ControlTableItem items_EXTMX[] {
+    {0  , "Model_Number"                  , 2},
+    {2  , "Firmware_Version"              , 1},
+    {3  , "ID"                            , 1},
+    {4  , "Baud_Rate"                     , 1},
+    {5  , "Return_Delay_Time"             , 1},
+    {6  , "CW_Angle_Limit"                , 2},
+    {8  , "CCW_Angle_Limit"               , 2},
+    {11 , "Temperature_Limit"             , 1},
+    {12 , "Min_Voltage_Limit"             , 1},
+    {13 , "Max_Voltage_Limit"             , 1},
+    {14 , "Max_Torque"                    , 2},
+    {16 , "Status_Return_Level"           , 1},
+    {17 , "Alarm_LED"                     , 1},
+    {18 , "Shutdown"                      , 1},
+    {20 , "Multi_Turn_Offset"             , 2},
+    {22 , "Resolution_Divider"            , 1},
 
-  item[4]  = {24 , "Torque_Enable"                 , 1};
-  item[5]  = {25 , "LED"                           , 1};
-  item[6]  = {30 , "Goal_Position"                 , 2};
-  item[7]  = {32 , "Moving_Speed"                  , 2};
-  item[8]  = {34 , "Torque_Limit"                  , 2};
-  item[9]  = {36 , "Present_Position"              , 2};
-  item[10] = {38 , "Present_Speed"                 , 2};
-  item[11] = {40 , "Present_Load"                  , 2};
-  item[12] = {46 , "Moving"                        , 1};
-  // item[13] = {68 , "Current"                       , 2};
-  // item[14] = {70 , "Torque_Control_Mode_Enable"    , 1};
-  // item[15] = {71 , "Goal_Torque"                   , 2};
-  // item[16] = {73 , "Goal_Acceleration"             , 1};
+    {24 , "Torque_Enable"                 , 1},
+    {25 , "LED"                           , 1},
+    {26 , "D_gain"                        , 1},
+    {27 , "I_gain"                        , 1},
+    {28 , "P_gain"                        , 1},
+    {30 , "Goal_Position"                 , 2},
+    {32 , "Moving_Speed"                  , 2},
+    {34 , "Torque_Limit"                  , 2},
+    {36 , "Present_Position"              , 2},
+    {38 , "Present_Speed"                 , 2},
+    {40 , "Present_Load"                  , 2},
+    {42 , "Present_Voltage"               , 1},
+    {43 , "Present_Temperature"           , 1},
+    {44 , "Registered"                    , 1},
+    {46 , "Moving"                        , 1},
+    {47 , "Lock"                          , 1},
+    {48 , "Punch"                         , 2},
+    {68 , "Current"                       , 2},
+    {70 , "Torque_Control_Mode_Enable"    , 1},
+    {71 , "Goal_Torque"                   , 2},
+    {73 , "Goal_Acceleration"             , 1} };
 
-  the_number_of_item = 13;
-#else
-  item[0]  = {0  , "Model_Number"                  , 2};
-  item[1]  = {2  , "Firmware_Version"              , 1};
-  item[2]  = {3  , "ID"                            , 1};
-  item[3]  = {4  , "Baud_Rate"                     , 1};
-  item[4]  = {5  , "Return_Delay_Time"             , 1};
-  item[5]  = {6  , "CW_Angle_Limit"                , 2};
-  item[6]  = {8  , "CCW_Angle_Limit"               , 2};
-  item[7]  = {11 , "Temperature_Limit"             , 1};
-  item[8]  = {12 , "Min_Voltage_Limit"             , 1};
-  item[9]  = {13 , "Max_Voltage_Limit"             , 1};
-  item[10] = {14 , "Max_Torque"                    , 2};
-  item[11] = {16 , "Status_Return_Level"           , 1};
-  item[12] = {17 , "Alarm_LED"                     , 1};
-  item[13] = {18 , "Shutdown"                      , 1};
-  item[14] = {20 , "Multi_Turn_Offset"             , 2};
-  item[15] = {22 , "Resolution_Divider"            , 1};
-
-  item[16] = {24 , "Torque_Enable"                 , 1};
-  item[17] = {25 , "LED"                           , 1};
-  item[18] = {26 , "D_gain"                        , 1};
-  item[19] = {27 , "I_gain"                        , 1};
-  item[20] = {28 , "P_gain"                        , 1};
-  item[21] = {30 , "Goal_Position"                 , 2};
-  item[22] = {32 , "Moving_Speed"                  , 2};
-  item[23] = {34 , "Torque_Limit"                  , 2};
-  item[24] = {36 , "Present_Position"              , 2};
-  item[25] = {38 , "Present_Speed"                 , 2};
-  item[26] = {40 , "Present_Load"                  , 2};
-  item[27] = {42 , "Present_Voltage"               , 1};
-  item[28] = {43 , "Present_Temperature"           , 1};
-  item[29] = {44 , "Registered"                    , 1};
-  item[30] = {46 , "Moving"                        , 1};
-  item[31] = {47 , "Lock"                          , 1};
-  item[32] = {48 , "Punch"                         , 2};
-  item[33] = {68 , "Current"                       , 2};
-  item[34] = {70 , "Torque_Control_Mode_Enable"    , 1};
-  item[35] = {71 , "Goal_Torque"                   , 2};
-  item[36] = {73 , "Goal_Acceleration"             , 1};
-
-  the_number_of_item = 37;
-#endif  
-}
+#define COUNT_EXTMX_ITEMS (sizeof(items_EXTMX)/sizeof(items_EXTMX[0]))
 
 static void setExtMXInfo()
 {
@@ -481,83 +364,64 @@ static void setExtMXInfo()
   model_info.max_radian                      =  3.14159265;
 }
 
-static void setExtMX2Item(void)
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {7  , "ID"                    , 1};
-  item[1]  = {8  , "Baud_Rate"             , 1};
-  item[2]  = {11 , "Operating_Mode"        , 1};
+//---------------------------------------------------------
+// EXT MX Protocol 2 Servos - (num == MX_64_2 || num == MX_106_2)
+//---------------------------------------------------------
+static const ControlTableItem items_EXTMX2[] {
+    {0  , "Model_Number"          , 2},
+    {6  , "Firmware_Version"      , 1},
+    {7  , "ID"                    , 1},
+    {8  , "Baud_Rate"             , 1},
+    {9  , "Return_Delay_Time"     , 1},
+    {10 , "Drive_Mode"            , 1},
+    {11 , "Operating_Mode"        , 1},
+    {12 , "Secondary_ID"          , 1},
+    {13 , "Protocol_Version"      , 1},
+    {20 , "Homing_Offset"         , 4},
+    {24 , "Moving_Threshold"      , 4},
+    {31 , "Temperature_Limit"     , 1},
+    {32 , "Max_Voltage_Limit"     , 2},
+    {34 , "Min_Voltage_Limit"     , 2},
+    {36 , "PWM_Limit"             , 2},
+    {40 , "Current_Limit"         , 2},
+    {40 , "Acceleration_Limit"    , 4},
+    {44 , "Velocity_Limit"        , 4},
+    {48 , "Max_Position_Limit"    , 4},
+    {52 , "Min_Position_Limit"    , 4},
+    {63 , "Shutdown"              , 1},
 
-  item[3]  = {64 , "Torque_Enable"         , 1};
-  item[4]  = {65 , "LED"                   , 1};
-  item[5]  = {102, "Goal_Current"          , 2};
-  item[6]  = {104, "Goal_Velocity"         , 4};
-  item[7]  = {108, "Profile_Acceleration"  , 4};
-  item[8]  = {112, "Profile_Velocity"      , 4};
-  item[9]  = {116, "Goal_Position"         , 4};
-  item[10] = {122, "Moving"                , 1};
-  item[11] = {126, "Present_Current"       , 2};
-  item[12] = {128, "Present_Velocity"      , 4};
-  item[13] = {132, "Present_Position"      , 4};
+    {64 , "Torque_Enable"         , 1},
+    {65 , "LED"                   , 1},
+    {68 , "Status_Return_Level"   , 1},
+    {69 , "Registered_Instruction", 1},
+    {70 , "Hardware_Error_Status" , 1},
+    {76 , "Velocity_I_Gain"       , 2},
+    {78 , "Velocity_P_Gain"       , 2},
+    {80 , "Position_D_Gain"       , 2},
+    {82 , "Position_I_Gain"       , 2},
+    {84 , "Position_P_Gain"       , 2},
+    {88 , "Feedforward_2nd_Gain"  , 2},
+    {90 , "Feedforward_1st_Gain"  , 2},
+    {98 , "Bus_Watchdog"          , 1},
+    {100, "Goal_PWM"              , 2},
+    {102, "Goal_Current"          , 2},
+    {104, "Goal_Velocity"         , 4},
+    {108, "Profile_Acceleration"  , 4},
+    {112, "Profile_Velocity"      , 4},
+    {116, "Goal_Position"         , 4},
+    {120, "Realtime_Tick"         , 2},
+    {122, "Moving"                , 1},
+    {123, "Moving_Status"         , 1},
+    {124, "Present_PWM"           , 2},
+    {126, "Present_Current"       , 2},
+    {128, "Present_Velocity"      , 4},
+    {132, "Present_Position"      , 4},
+    {136, "Velocity_Trajectory"   , 4},
+    {140, "Position_Trajectory"   , 4},
+    {144, "Present_Input Voltage" , 2},
+    {146, "Present_Temperature"   , 1}};
 
-  the_number_of_item = 14;
-#else
-  item[0]  = {0  , "Model_Number"          , 2};
-  item[1]  = {6  , "Firmware_Version"      , 1};
-  item[2]  = {7  , "ID"                    , 1};
-  item[3]  = {8  , "Baud_Rate"             , 1};
-  item[4]  = {9  , "Return_Delay_Time"     , 1};
-  item[5]  = {10 , "Drive_Mode"            , 1};
-  item[6]  = {11 , "Operating_Mode"        , 1};
-  item[7]  = {12 , "Secondary_ID"          , 1};
-  item[8]  = {13 , "Protocol_Version"      , 1};
-  item[9]  = {20 , "Homing_Offset"         , 4};
-  item[10] = {24 , "Moving_Threshold"      , 4};
-  item[11] = {31 , "Temperature_Limit"     , 1};
-  item[12] = {32 , "Max_Voltage_Limit"     , 2};
-  item[13] = {34 , "Min_Voltage_Limit"     , 2};
-  item[14] = {36 , "PWM_Limit"             , 2};
-  item[15] = {40 , "Current_Limit"         , 2};
-  item[16] = {40 , "Acceleration_Limit"    , 4};
-  item[17] = {44 , "Velocity_Limit"        , 4};
-  item[18] = {48 , "Max_Position_Limit"    , 4};
-  item[19] = {52 , "Min_Position_Limit"    , 4};
-  item[20] = {63 , "Shutdown"              , 1};
-
-  item[21] = {64 , "Torque_Enable"         , 1};
-  item[22] = {65 , "LED"                   , 1};
-  item[23] = {68 , "Status_Return_Level"   , 1};
-  item[24] = {69 , "Registered_Instruction", 1};
-  item[25] = {70 , "Hardware_Error_Status" , 1};
-  item[26] = {76 , "Velocity_I_Gain"       , 2};
-  item[27] = {78 , "Velocity_P_Gain"       , 2};
-  item[28] = {80 , "Position_D_Gain"       , 2};
-  item[29] = {82 , "Position_I_Gain"       , 2};
-  item[30] = {84 , "Position_P_Gain"       , 2};
-  item[31] = {88 , "Feedforward_2nd_Gain"  , 2};
-  item[32] = {90 , "Feedforward_1st_Gain"  , 2};
-  item[33] = {98 , "Bus_Watchdog"          , 1};
-  item[34] = {100, "Goal_PWM"              , 2};
-  item[35] = {102, "Goal_Current"          , 2};
-  item[36] = {104, "Goal_Velocity"         , 4};
-  item[37] = {108, "Profile_Acceleration"  , 4};
-  item[38] = {112, "Profile_Velocity"      , 4};
-  item[39] = {116, "Goal_Position"         , 4};
-  item[40] = {120, "Realtime_Tick"         , 2};
-  item[41] = {122, "Moving"                , 1};
-  item[42] = {123, "Moving_Status"         , 1};
-  item[43] = {124, "Present_PWM"           , 2};
-  item[44] = {126, "Present_Current"       , 2};
-  item[45] = {128, "Present_Velocity"      , 4};
-  item[46] = {132, "Present_Position"      , 4};
-  item[47] = {136, "Velocity_Trajectory"   , 4};
-  item[48] = {140, "Position_Trajectory"   , 4};
-  item[49] = {144, "Present_Input Voltage" , 2};
-  item[50] = {146, "Present_Temperature"   , 1};
-
-  the_number_of_item = 51;
-#endif  
-}
+#define COUNT_EXTMX2_ITEMS (sizeof(items_EXTMX2)/sizeof(items_EXTMX2[0]))
 
 static void setExtMX2Info(void)
 {
@@ -571,63 +435,44 @@ static void setExtMX2Info(void)
   model_info.max_radian                      =  3.14159265;
 }
 
-static void setXL320Item()
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {3  , "ID"                            , 1};
-  item[1]  = {4  , "Baud_Rate"                     , 1};
-  item[2]  = {6  , "CW_Angle_Limit"                , 2};
-  item[3]  = {8  , "CCW_Angle_Limit"               , 2};
-  item[4]  = {11 , "Control_Mode"                  , 1};
+//---------------------------------------------------------
+// XL320 - (num == XL_320)
+//---------------------------------------------------------
+static const ControlTableItem items_XL320[] {
+    {0  , "Model_Number"                  , 2},
+    {2  , "Firmware_Version"              , 1},
+    {3  , "ID"                            , 1},
+    {4  , "Baud_Rate"                     , 1},
+    {5  , "Return_Delay_Time"             , 1},
+    {6  , "CW_Angle_Limit"                , 2},
+    {8  , "CCW_Angle_Limit"               , 2},
+    {11 , "Control_Mode"                  , 1},
+    {12 , "Temperature_Limit"             , 1},
+    {13 , "Min_Voltage_Limit"             , 1},
+    {14 , "Max_Voltage_Limit"             , 1},
+    {15 , "Max_Torque"                    , 2},
+    {17 , "Status_Return_Level"           , 1},
+    {18 , "Shutdown"                      , 1},
 
-  item[5]  = {24 , "Torque_ON/OFF"                 , 1};
-  item[6]  = {25 , "LED"                           , 1};
-  item[7]  = {30 , "Goal_Position"                 , 2};
-  item[8]  = {32 , "Moving_Speed"                  , 2};
-  item[9]  = {34 , "Torque_Limit"                  , 2};
-  item[10] = {37 , "Present_Position"              , 2};
-  item[11] = {39 , "Present_Speed"                 , 2};
-  item[12] = {41 , "Present_Load"                  , 2};
-  item[13] = {49 , "Moving"                        , 1};
+    {24 , "Torque_Enable"                 , 1},
+    {25 , "LED"                           , 1},
+    {27 , "D_gain"                        , 1},
+    {28 , "I_gain"                        , 1},
+    {29 , "P_gain"                        , 1},
+    {30 , "Goal_Position"                 , 2},
+    {32 , "Moving_Speed"                  , 2},
+    {34 , "Torque_Limit"                  , 2},
+    {37 , "Present_Position"              , 2},
+    {39 , "Present_Speed"                 , 2},
+    {41 , "Present_Load"                  , 2},
+    {45 , "Present_Voltage"               , 1},
+    {46 , "Present_Temperature"           , 1},
+    {47 , "Registered"                    , 1},
+    {49 , "Moving"                        , 1},
+    {50 , "Hardware_Error_Status"         , 1},
+    {51 , "Punch"                         , 2} };
 
-  the_number_of_item = 14;
-#else
-  item[0]  = {0  , "Model_Number"                  , 2};
-  item[1]  = {2  , "Firmware_Version"              , 1};
-  item[2]  = {3  , "ID"                            , 1};
-  item[3]  = {4  , "Baud_Rate"                     , 1};
-  item[4]  = {5  , "Return_Delay_Time"             , 1};
-  item[5]  = {6  , "CW_Angle_Limit"                , 2};
-  item[6]  = {8  , "CCW_Angle_Limit"               , 2};
-  item[7]  = {11 , "Control_Mode"                  , 1};
-  item[8]  = {12 , "Temperature_Limit"             , 1};
-  item[9]  = {13 , "Min_Voltage_Limit"             , 1};
-  item[10] = {14 , "Max_Voltage_Limit"             , 1};
-  item[11] = {15 , "Max_Torque"                    , 2};
-  item[12] = {17 , "Status_Return_Level"           , 1};
-  item[13] = {18 , "Shutdown"                      , 1};
-
-  item[14] = {24 , "Torque_Enable"                 , 1};
-  item[15] = {25 , "LED"                           , 1};
-  item[16] = {27 , "D_gain"                        , 1};
-  item[17] = {28 , "I_gain"                        , 1};
-  item[18] = {29 , "P_gain"                        , 1};
-  item[19] = {30 , "Goal_Position"                 , 2};
-  item[20] = {32 , "Moving_Speed"                  , 2};
-  item[21] = {34 , "Torque_Limit"                  , 2};
-  item[22] = {37 , "Present_Position"              , 2};
-  item[23] = {39 , "Present_Speed"                 , 2};
-  item[24] = {41 , "Present_Load"                  , 2};
-  item[25] = {45 , "Present_Voltage"               , 1};
-  item[26] = {46 , "Present_Temperature"           , 1};
-  item[27] = {47 , "Registered"                    , 1};
-  item[28] = {49 , "Moving"                        , 1};
-  item[29] = {50 , "Hardware_Error_Status"         , 1};
-  item[30] = {51 , "Punch"                         , 2};
-
-  the_number_of_item = 31;
-#endif  
-}
+#define COUNT_XL320_ITEMS (sizeof(items_XL320)/sizeof(items_XL320[0]))
 
 static void setXL320Info()
 {
@@ -641,81 +486,62 @@ static void setXL320Info()
   model_info.max_radian                      =  2.61799;
 }
 
-static void setXLItem()
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {7  , "ID"                    , 1};
-  item[1]  = {8  , "Baud_Rate"             , 1};
-  item[2]  = {11 , "Operating_Mode"        , 1};
+//---------------------------------------------------------
+// XL - (num == XL430_W250)
+//---------------------------------------------------------
+static const ControlTableItem items_XL[] {
+    {0  , "Model_Number"          , 2},
+    {6  , "Firmware_Version"      , 1},
+    {7  , "ID"                    , 1},
+    {8  , "Baud_Rate"             , 1},
+    {9  , "Return_Delay_Time"     , 1},
+    {10 , "Drive_Mode"            , 1},
+    {11 , "Operating_Mode"        , 1},
+    {12 , "Secondary_ID"          , 1},
+    {13 , "Protocol_Version"      , 1},
+    {20 , "Homing_Offset"         , 4},
+    {24 , "Moving_Threshold"      , 4},
+    {31 , "Temperature_Limit"     , 1},
+    {32 , "Max_Voltage_Limit"     , 2},
+    {34 , "Min_Voltage_Limit"     , 2},
+    {36 , "PWM_Limit"             , 2},
+    {40 , "Acceleration_Limit"    , 4},
+    {44 , "Velocity_Limit"        , 4},
+    {48 , "Max_Position_Limit"    , 4},
+    {52 , "Min_Position_Limit"    , 4},
+    {63 , "Shutdown"              , 1},
 
-  item[3]  = {64 , "Torque_Enable"         , 1};
-  item[4]  = {65 , "LED"                   , 1};
-  item[5]  = {102, "Goal_Current"          , 2};
-  item[6]  = {104, "Goal_Velocity"         , 4};
-  item[7]  = {108, "Profile_Acceleration"  , 4};
-  item[8]  = {112, "Profile_Velocity"      , 4};
-  item[9]  = {116, "Goal_Position"         , 4};
-  item[10] = {122, "Moving"                , 1};
-  item[11] = {126, "Present_Load"          , 2};
-  item[12] = {128, "Present_Velocity"      , 4};
-  item[13] = {132, "Present_Position"      , 4};
+    {64 , "Torque_Enable"         , 1},
+    {65 , "LED"                   , 1},
+    {68 , "Status_Return_Level"   , 1},
+    {69 , "Registered_Instruction", 1},
+    {70 , "Hardware_Error_Status" , 1},
+    {76 , "Velocity_I_Gain"       , 2},
+    {78 , "Velocity_P_Gain"       , 2},
+    {80 , "Position_D_Gain"       , 2},
+    {82 , "Position_I_Gain"       , 2},
+    {84 , "Position_P_Gain"       , 2},
+    {88 , "Feedforward_2nd_Gain"  , 2},
+    {90 , "Feedforward_1st_Gain"  , 2},
+    {98 , "Bus_Watchdog"          , 1},
+    {100, "Goal_PWM"              , 2},
+    {104, "Goal_Velocity"         , 4},
+    {108, "Profile_Acceleration"  , 4},
+    {112, "Profile_Velocity"      , 4},
+    {116, "Goal_Position"         , 4},
+    {120, "Realtime_Tick"         , 2},
+    {122, "Moving"                , 1},
+    {123, "Moving_Status"         , 1},
+    {124, "Present_PWM"           , 2},
+    {126, "Present_Load"          , 2},
+    {128, "Present_Velocity"      , 4},
+    {132, "Present_Position"      , 4},
+    {136, "Velocity_Trajectory"   , 4},
+    {140, "Position_Trajectory"   , 4},
+    {144, "Present_Input_Voltage" , 2},
+    {146, "Present_Temperature"   , 1} };
 
-  the_number_of_item = 14;
-#else
-  item[0]  = {0  , "Model_Number"          , 2};
-  item[1]  = {6  , "Firmware_Version"      , 1};
-  item[2]  = {7  , "ID"                    , 1};
-  item[3]  = {8  , "Baud_Rate"             , 1};
-  item[4]  = {9  , "Return_Delay_Time"     , 1};
-  item[5]  = {10 , "Drive_Mode"            , 1};
-  item[6]  = {11 , "Operating_Mode"        , 1};
-  item[7]  = {12 , "Secondary_ID"          , 1};
-  item[8]  = {13 , "Protocol_Version"      , 1};
-  item[9]  = {20 , "Homing_Offset"         , 4};
-  item[10] = {24 , "Moving_Threshold"      , 4};
-  item[11] = {31 , "Temperature_Limit"     , 1};
-  item[12] = {32 , "Max_Voltage_Limit"     , 2};
-  item[13] = {34 , "Min_Voltage_Limit"     , 2};
-  item[14] = {36 , "PWM_Limit"             , 2};
-  item[15] = {40 , "Acceleration_Limit"    , 4};
-  item[16] = {44 , "Velocity_Limit"        , 4};
-  item[17] = {48 , "Max_Position_Limit"    , 4};
-  item[18] = {52 , "Min_Position_Limit"    , 4};
-  item[19] = {63 , "Shutdown"              , 1};
-
-  item[20] = {64 , "Torque_Enable"         , 1};
-  item[21] = {65 , "LED"                   , 1};
-  item[22] = {68 , "Status_Return_Level"   , 1};
-  item[23] = {69 , "Registered_Instruction", 1};
-  item[24] = {70 , "Hardware_Error_Status" , 1};
-  item[25] = {76 , "Velocity_I_Gain"       , 2};
-  item[26] = {78 , "Velocity_P_Gain"       , 2};
-  item[27] = {80 , "Position_D_Gain"       , 2};
-  item[28] = {82 , "Position_I_Gain"       , 2};
-  item[29] = {84 , "Position_P_Gain"       , 2};
-  item[30] = {88 , "Feedforward_2nd_Gain"  , 2};
-  item[31] = {90 , "Feedforward_1st_Gain"  , 2};
-  item[32] = {98 , "Bus_Watchdog"          , 1};
-  item[33] = {100, "Goal_PWM"              , 2};
-  item[34] = {104, "Goal_Velocity"         , 4};
-  item[35] = {108, "Profile_Acceleration"  , 4};
-  item[36] = {112, "Profile_Velocity"      , 4};
-  item[37] = {116, "Goal_Position"         , 4};
-  item[38] = {120, "Realtime_Tick"         , 2};
-  item[39] = {122, "Moving"                , 1};
-  item[40] = {123, "Moving_Status"         , 1};
-  item[41] = {124, "Present_PWM"           , 2};
-  item[42] = {126, "Present_Load"          , 2};
-  item[43] = {128, "Present_Velocity"      , 4};
-  item[44] = {132, "Present_Position"      , 4};
-  item[45] = {136, "Velocity_Trajectory"   , 4};
-  item[46] = {140, "Position_Trajectory"   , 4};
-  item[47] = {144, "Present_Input_Voltage" , 2};
-  item[48] = {146, "Present_Temperature"   , 1};
-
-  the_number_of_item = 49;
-#endif  
-}
+#define COUNT_XL_ITEMS (sizeof(items_XL)/sizeof(items_XL[0]))
 
 static void setXLInfo()
 {
@@ -729,83 +555,64 @@ static void setXLInfo()
   model_info.max_radian                      =  3.14159265;
 }
 
-static void setXMItem()
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {7  , "ID"                    , 1};
-  item[1]  = {8  , "Baud_Rate"             , 1};
-  item[2]  = {11 , "Operating_Mode"        , 1};
+//---------------------------------------------------------
+// XM - (num == XM430_W210 || num == XM430_W350)
+//---------------------------------------------------------
+static const ControlTableItem items_XM[] {
+    {0  , "Model_Number"          , 2},
+    {6  , "Firmware_Version"      , 1},
+    {7  , "ID"                    , 1},
+    {8  , "Baud_Rate"             , 1},
+    {9  , "Return_Delay_Time"     , 1},
+    {10 , "Drive_Mode"            , 1},
+    {11 , "Operating_Mode"        , 1},
+    {12 , "Secondary_ID"          , 1},
+    {13 , "Protocol_Version"      , 1},
+    {20 , "Homing_Offset"         , 4},
+    {24 , "Moving_Threshold"      , 4},
+    {31 , "Temperature_Limit"     , 1},
+    {32 , "Max_Voltage_Limit"     , 2},
+    {34 , "Min_Voltage_Limit"     , 2},
+    {36 , "PWM_Limit"             , 2},
+    {40 , "Current_Limit"         , 2},
+    {40 , "Acceleration_Limit"    , 4},
+    {44 , "Velocity_Limit"        , 4},
+    {48 , "Max_Position_Limit"    , 4},
+    {52 , "Min_Position_Limit"    , 4},
+    {63 , "Shutdown"              , 1},
 
-  item[3]  = {64 , "Torque_Enable"         , 1};
-  item[4]  = {65 , "LED"                   , 1};
-  item[5]  = {102, "Goal_Current"          , 2};
-  item[6]  = {104, "Goal_Velocity"         , 4};
-  item[7]  = {108, "Profile_Acceleration"  , 4};
-  item[8]  = {112, "Profile_Velocity"      , 4};
-  item[9]  = {116, "Goal_Position"         , 4};
-  item[10] = {122, "Moving"                , 1};
-  item[11] = {126, "Present_Current"       , 2};
-  item[12] = {128, "Present_Velocity"      , 4};
-  item[13] = {132, "Present_Position"      , 4};
+    {64 , "Torque_Enable"         , 1},
+    {65 , "LED"                   , 1},
+    {68 , "Status_Return_Level"   , 1},
+    {69 , "Registered_Instruction", 1},
+    {70 , "Hardware_Error_Status" , 1},
+    {76 , "Velocity_I_Gain"       , 2},
+    {78 , "Velocity_P_Gain"       , 2},
+    {80 , "Position_D_Gain"       , 2},
+    {82 , "Position_I_Gain"       , 2},
+    {84 , "Position_P_Gain"       , 2},
+    {88 , "Feedforward_2nd_Gain"  , 2},
+    {90 , "Feedforward_1st_Gain"  , 2},
+    {98 , "Bus_Watchdog"          , 1},
+    {100, "Goal_PWM"              , 2},
+    {102, "Goal_Current"          , 2},
+    {104, "Goal_Velocity"         , 4},
+    {108, "Profile_Acceleration"  , 4},
+    {112, "Profile_Velocity"      , 4},
+    {116, "Goal_Position"         , 4},
+    {120, "Realtime_Tick"         , 2},
+    {122, "Moving"                , 1},
+    {123, "Moving_Status"         , 1},
+    {124, "Present_PWM"           , 2},
+    {126, "Present_Current"       , 2},
+    {128, "Present_Velocity"      , 4},
+    {132, "Present_Position"      , 4},
+    {136, "Velocity_Trajectory"   , 4},
+    {140, "Position_Trajectory"   , 4},
+    {144, "Present_Input_Voltage" , 2},
+    {146, "Present_Temperature"   , 1} };
 
-  the_number_of_item = 14;
-#else
-  item[0]  = {0  , "Model_Number"          , 2};
-  item[1]  = {6  , "Firmware_Version"      , 1};
-  item[2]  = {7  , "ID"                    , 1};
-  item[3]  = {8  , "Baud_Rate"             , 1};
-  item[4]  = {9  , "Return_Delay_Time"     , 1};
-  item[5]  = {10 , "Drive_Mode"            , 1};
-  item[6]  = {11 , "Operating_Mode"        , 1};
-  item[7]  = {12 , "Secondary_ID"          , 1};
-  item[8]  = {13 , "Protocol_Version"      , 1};
-  item[9]  = {20 , "Homing_Offset"         , 4};
-  item[10] = {24 , "Moving_Threshold"      , 4};
-  item[11] = {31 , "Temperature_Limit"     , 1};
-  item[12] = {32 , "Max_Voltage_Limit"     , 2};
-  item[13] = {34 , "Min_Voltage_Limit"     , 2};
-  item[14] = {36 , "PWM_Limit"             , 2};
-  item[15] = {40 , "Current_Limit"         , 2};
-  item[16] = {40 , "Acceleration_Limit"    , 4};
-  item[17] = {44 , "Velocity_Limit"        , 4};
-  item[18] = {48 , "Max_Position_Limit"    , 4};
-  item[19] = {52 , "Min_Position_Limit"    , 4};
-  item[20] = {63 , "Shutdown"              , 1};
-
-  item[21] = {64 , "Torque_Enable"         , 1};
-  item[22] = {65 , "LED"                   , 1};
-  item[23] = {68 , "Status_Return_Level"   , 1};
-  item[24] = {69 , "Registered_Instruction", 1};
-  item[25] = {70 , "Hardware_Error_Status" , 1};
-  item[26] = {76 , "Velocity_I_Gain"       , 2};
-  item[27] = {78 , "Velocity_P_Gain"       , 2};
-  item[28] = {80 , "Position_D_Gain"       , 2};
-  item[29] = {82 , "Position_I_Gain"       , 2};
-  item[30] = {84 , "Position_P_Gain"       , 2};
-  item[31] = {88 , "Feedforward_2nd_Gain"  , 2};
-  item[32] = {90 , "Feedforward_1st_Gain"  , 2};
-  item[33] = {98 , "Bus_Watchdog"          , 1};
-  item[34] = {100, "Goal_PWM"              , 2};
-  item[35] = {102, "Goal_Current"          , 2};
-  item[36] = {104, "Goal_Velocity"         , 4};
-  item[37] = {108, "Profile_Acceleration"  , 4};
-  item[38] = {112, "Profile_Velocity"      , 4};
-  item[39] = {116, "Goal_Position"         , 4};
-  item[40] = {120, "Realtime_Tick"         , 2};
-  item[41] = {122, "Moving"                , 1};
-  item[42] = {123, "Moving_Status"         , 1};
-  item[43] = {124, "Present_PWM"           , 2};
-  item[44] = {126, "Present_Current"       , 2};
-  item[45] = {128, "Present_Velocity"      , 4};
-  item[46] = {132, "Present_Position"      , 4};
-  item[47] = {136, "Velocity_Trajectory"   , 4};
-  item[48] = {140, "Position_Trajectory"   , 4};
-  item[49] = {144, "Present_Input_Voltage" , 2};
-  item[50] = {146, "Present_Temperature"   , 1};
-
-  the_number_of_item = 51;
-#endif  
-}
+#define COUNT_XM_ITEMS (sizeof(items_XM)/sizeof(items_XM[0]))
 
 static void setXMInfo()
 {
@@ -820,86 +627,67 @@ static void setXMInfo()
   model_info.max_radian =  3.14159265;
 }
 
-static void setExtXMItem(void)
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {7  , "ID"                    , 1};
-  item[1]  = {8  , "Baud_Rate"             , 1};
-  item[2]  = {11 , "Operating_Mode"        , 1};
+//---------------------------------------------------------
+// EXTXM - (num == XM540_W150 || num == XM540_W270)
+//---------------------------------------------------------
+static const ControlTableItem items_EXTXM[] {
+    {0  , "Model_Number"          , 2},
+    {6  , "Firmware_Version"      , 1},
+    {7  , "ID"                    , 1},
+    {8  , "Baud_Rate"             , 1},
+    {9  , "Return_Delay_Time"     , 1},
+    {10 , "Drive_Mode"            , 1},
+    {11 , "Operating_Mode"        , 1},
+    {12 , "Secondary_ID"          , 1},
+    {13 , "Protocol_Version"      , 1},
+    {20 , "Homing_Offset"         , 4},
+    {24 , "Moving_Threshold"      , 4},
+    {31 , "Temperature_Limit"     , 1},
+    {32 , "Max Voltage_Limit"     , 2},
+    {34 , "Min Voltage_Limit"     , 2},
+    {36 , "PWM_Limit"             , 2},
+    {40 , "Current_Limit"         , 2},
+    {40 , "Acceleration_Limit"    , 4},
+    {44 , "Velocity_Limit"        , 4},
+    {48 , "Max_Position_Limit"    , 4},
+    {52 , "Min_Position_Limit"    , 4},
+    {56 , "External_Port_Mode_1"  , 1},
+    {57 , "External_Port_Mode_2"  , 1},
+    {58 , "External_Port_Mode_3"  , 1},
+    {63 , "Shutdown"              , 1},
 
-  item[3]  = {64 , "Torque_Enable"         , 1};
-  item[4]  = {65 , "LED"                   , 1};
-  item[5]  = {102, "Goal_Current"          , 2};
-  item[6]  = {104, "Goal_Velocity"         , 4};
-  item[7]  = {108, "Profile_Acceleration"  , 4};
-  item[8]  = {112, "Profile_Velocity"      , 4};
-  item[9] = {116, "Goal_Position"         , 4};
-  item[10] = {122, "Moving"                , 1};
-  item[11] = {126, "Present_Current"       , 2};
-  item[12] = {128, "Present_Velocity"      , 4};
-  item[13] = {132, "Present_Position"      , 4};
+    {64 , "Torque_Enable"         , 1},
+    {65 , "LED"                   , 1},
+    {68 , "Status_Return_Level"   , 1},
+    {69 , "Registered_Instruction", 1},
+    {70 , "Hardware_Error_Status" , 1},
+    {76 , "Velocity_I_Gain"       , 2},
+    {78 , "Velocity_P_Gain"       , 2},
+    {80 , "Position_D_Gain"       , 2},
+    {82 , "Position_I_Gain"       , 2},
+    {84 , "Position_P_Gain"       , 2},
+    {88 , "Feedforward_2nd_Gain"  , 2},
+    {90 , "Feedforward_1st_Gain"  , 2},
+    {98 , "Bus_Watchdog"          , 1},
+    {100, "Goal_PWM"              , 2},
+    {102, "Goal_Current"          , 2},
+    {104, "Goal_Velocity"         , 4},
+    {108, "Profile_Acceleration"  , 4},
+    {112, "Profile_Velocity"      , 4},
+    {116, "Goal_Position"         , 4},
+    {120, "Realtime_Tick"         , 2},
+    {122, "Moving"                , 1},
+    {123, "Moving_Status"         , 1},
+    {124, "Present_PWM"           , 2},
+    {126, "Present_Current"       , 2},
+    {128, "Present_Velocity"      , 4},
+    {132, "Present_Position"      , 4},
+    {136, "Velocity_Trajectory"   , 4},
+    {140, "Position_Trajectory"   , 4},
+    {144, "Present_Input_Voltage" , 2},
+    {146, "Present_Temperature"   , 1} };
 
-  the_number_of_item = 14;
-#else
-  item[0]  = {0  , "Model_Number"          , 2};
-  item[1]  = {6  , "Firmware_Version"      , 1};
-  item[2]  = {7  , "ID"                    , 1};
-  item[3]  = {8  , "Baud_Rate"             , 1};
-  item[4]  = {9  , "Return_Delay_Time"     , 1};
-  item[5]  = {10 , "Drive_Mode"            , 1};
-  item[6]  = {11 , "Operating_Mode"        , 1};
-  item[7]  = {12 , "Secondary_ID"          , 1};
-  item[8]  = {13 , "Protocol_Version"      , 1};
-  item[9]  = {20 , "Homing_Offset"         , 4};
-  item[10] = {24 , "Moving_Threshold"      , 4};
-  item[11] = {31 , "Temperature_Limit"     , 1};
-  item[12] = {32 , "Max Voltage_Limit"     , 2};
-  item[13] = {34 , "Min Voltage_Limit"     , 2};
-  item[14] = {36 , "PWM_Limit"             , 2};
-  item[15] = {40 , "Current_Limit"         , 2};
-  item[16] = {40 , "Acceleration_Limit"    , 4};
-  item[17] = {44 , "Velocity_Limit"        , 4};
-  item[18] = {48 , "Max_Position_Limit"    , 4};
-  item[19] = {52 , "Min_Position_Limit"    , 4};
-  item[20] = {56 , "External_Port_Mode_1"  , 1};
-  item[21] = {57 , "External_Port_Mode_2"  , 1};
-  item[22] = {58 , "External_Port_Mode_3"  , 1};
-  item[23] = {63 , "Shutdown"              , 1};
-
-  item[24] = {64 , "Torque_Enable"         , 1};
-  item[25] = {65 , "LED"                   , 1};
-  item[26] = {68 , "Status_Return_Level"   , 1};
-  item[27] = {69 , "Registered_Instruction", 1};
-  item[28] = {70 , "Hardware_Error_Status" , 1};
-  item[29] = {76 , "Velocity_I_Gain"       , 2};
-  item[30] = {78 , "Velocity_P_Gain"       , 2};
-  item[31] = {80 , "Position_D_Gain"       , 2};
-  item[32] = {82 , "Position_I_Gain"       , 2};
-  item[33] = {84 , "Position_P_Gain"       , 2};
-  item[34] = {88 , "Feedforward_2nd_Gain"  , 2};
-  item[35] = {90 , "Feedforward_1st_Gain"  , 2};
-  item[36] = {98 , "Bus_Watchdog"          , 1};
-  item[37] = {100, "Goal_PWM"              , 2};
-  item[38] = {102, "Goal_Current"          , 2};
-  item[39] = {104, "Goal_Velocity"         , 4};
-  item[40] = {108, "Profile_Acceleration"  , 4};
-  item[41] = {112, "Profile_Velocity"      , 4};
-  item[42] = {116, "Goal_Position"         , 4};
-  item[43] = {120, "Realtime_Tick"         , 2};
-  item[44] = {122, "Moving"                , 1};
-  item[45] = {123, "Moving_Status"         , 1};
-  item[46] = {124, "Present_PWM"           , 2};
-  item[47] = {126, "Present_Current"       , 2};
-  item[48] = {128, "Present_Velocity"      , 4};
-  item[49] = {132, "Present_Position"      , 4};
-  item[50] = {136, "Velocity_Trajectory"   , 4};
-  item[51] = {140, "Position_Trajectory"   , 4};
-  item[52] = {144, "Present_Input_Voltage" , 2};
-  item[53] = {146, "Present_Temperature"   , 1};
-
-  the_number_of_item = 54;
-#endif  
-}
+#define COUNT_EXTXM_ITEMS (sizeof(items_EXTXM)/sizeof(items_EXTXM[0]))
 
 static void setExtXMInfo(void)
 {
@@ -913,83 +701,65 @@ static void setExtXMInfo(void)
   model_info.max_radian =  3.14159265;
 }
 
-static void setXHItem()
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {7  , "ID"                    , 1};
-  item[1]  = {8  , "Baud_Rate"             , 1};
-  item[2]  = {11 , "Operating_Mode"        , 1};
+//---------------------------------------------------------
+// XH - (num == XH430_V210 || num == XH430_V350 || num == XH430_W210 || num == XH430_W350)
+//---------------------------------------------------------
+static const ControlTableItem items_XH[] {
+    {0  , "Model_Number"          , 2},
+    {6  , "Firmware_Version"      , 1},
+    {7  , "ID"                    , 1},
+    {8  , "Baud_Rate"             , 1},
+    {9  , "Return_Delay_Time"     , 1},
+    {10 , "Drive_Mode"            , 1},
+    {11 , "Operating_Mode"        , 1},
+    {12 , "Secondary_ID"          , 1},
+    {13 , "Protocol_Version"      , 1},
+    {20 , "Homing_Offset"         , 4},
+    {24 , "Moving_Threshold"      , 4},
+    {31 , "Temperature_Limit"     , 1},
+    {32 , "Max_Voltage_Limit"     , 2},
+    {34 , "Min_Voltage_Limit"     , 2},
+    {36 , "PWM_Limit"             , 2},
+    {40 , "Current_Limit"         , 2},
+    {40 , "Acceleration_Limit"    , 4},
+    {44 , "Velocity_Limit"        , 4},
+    {48 , "Max_Position_Limit"    , 4},
+    {52 , "Min_Position_Limit"    , 4},
+    {63 , "Shutdown"              , 1},
 
-  item[3]  = {64 , "Torque_Enable"         , 1};
-  item[4]  = {65 , "LED"                   , 1};
-  item[5]  = {102, "Goal_Current"          , 2};
-  item[6]  = {104, "Goal_Velocity"         , 4};
-  item[7]  = {108, "Profile_Acceleration"  , 4};
-  item[8]  = {112, "Profile_Velocity"      , 4};
-  item[9]  = {116, "Goal_Position"         , 4};
-  item[10] = {122, "Moving"                , 1};
-  item[11] = {126, "Present_Current"       , 2};
-  item[12] = {128, "Present_Velocity"      , 4};
-  item[13] = {132, "Present_Position"      , 4};
+    {64 , "Torque_Enable"         , 1},
+    {65 , "LED"                   , 1},
+    {68 , "Status_Return_Level"   , 1},
+    {69 , "Registered_Instruction", 1},
+    {70 , "Hardware_Error_Status" , 1},
+    {76 , "Velocity_I_Gain"       , 2},
+    {78 , "Velocity_P_Gain"       , 2},
+    {80 , "Position_D_Gain"       , 2},
+    {82 , "Position_I_Gain"       , 2},
+    {84 , "Position_P_Gain"       , 2},
+    {88 , "Feedforward_2nd_Gain"  , 2},
+    {90 , "Feedforward_1st_Gain"  , 2},
+    {98 , "Bus_Watchdog"          , 1},
+    {100, "Goal_PWM"              , 2},
+    {102, "Goal_Current"          , 2},
+    {104, "Goal_Velocity"         , 4},
+    {108, "Profile_Acceleration"  , 4},
+    {112, "Profile_Velocity"      , 4},
+    {116, "Goal_Position"         , 4},
+    {120, "Realtime_Tick"         , 2},
+    {122, "Moving"                , 1},
+    {123, "Moving_Status"         , 1},
+    {124, "Present_PWM"           , 2},
+    {126, "Present_Current"       , 2},
+    {128, "Present_Velocity"      , 4},
+    {132, "Present_Position"      , 4},
+    {136, "Velocity_Trajectory"   , 4},
+    {140, "Position_Trajectory"   , 4},
+    {144, "Present_Input_Voltage" , 2},
+    {146, "Present_Temperature"   , 1} };
 
-  the_number_of_item = 14;
-#else
-  item[0]  = {0  , "Model_Number"          , 2};
-  item[1]  = {6  , "Firmware_Version"      , 1};
-  item[2]  = {7  , "ID"                    , 1};
-  item[3]  = {8  , "Baud_Rate"             , 1};
-  item[4]  = {9  , "Return_Delay_Time"     , 1};
-  item[5]  = {10 , "Drive_Mode"            , 1};
-  item[6]  = {11 , "Operating_Mode"        , 1};
-  item[7]  = {12 , "Secondary_ID"          , 1};
-  item[8]  = {13 , "Protocol_Version"      , 1};
-  item[9]  = {20 , "Homing_Offset"         , 4};
-  item[10] = {24 , "Moving_Threshold"      , 4};
-  item[11] = {31 , "Temperature_Limit"     , 1};
-  item[12] = {32 , "Max_Voltage_Limit"     , 2};
-  item[13] = {34 , "Min_Voltage_Limit"     , 2};
-  item[14] = {36 , "PWM_Limit"             , 2};
-  item[15] = {40 , "Current_Limit"         , 2};
-  item[16] = {40 , "Acceleration_Limit"    , 4};
-  item[17] = {44 , "Velocity_Limit"        , 4};
-  item[18] = {48 , "Max_Position_Limit"    , 4};
-  item[19] = {52 , "Min_Position_Limit"    , 4};
-  item[20] = {63 , "Shutdown"              , 1};
+#define COUNT_XH_ITEMS (sizeof(items_XH)/sizeof(items_XH[0]))
 
-  item[21] = {64 , "Torque_Enable"         , 1};
-  item[22] = {65 , "LED"                   , 1};
-  item[23] = {68 , "Status_Return_Level"   , 1};
-  item[24] = {69 , "Registered_Instruction", 1};
-  item[25] = {70 , "Hardware_Error_Status" , 1};
-  item[26] = {76 , "Velocity_I_Gain"       , 2};
-  item[27] = {78 , "Velocity_P_Gain"       , 2};
-  item[28] = {80 , "Position_D_Gain"       , 2};
-  item[29] = {82 , "Position_I_Gain"       , 2};
-  item[30] = {84 , "Position_P_Gain"       , 2};
-  item[31] = {88 , "Feedforward_2nd_Gain"  , 2};
-  item[32] = {90 , "Feedforward_1st_Gain"  , 2};
-  item[33] = {98 , "Bus_Watchdog"          , 1};
-  item[34] = {100, "Goal_PWM"              , 2};
-  item[35] = {102, "Goal_Current"          , 2};
-  item[36] = {104, "Goal_Velocity"         , 4};
-  item[37] = {108, "Profile_Acceleration"  , 4};
-  item[38] = {112, "Profile_Velocity"      , 4};
-  item[39] = {116, "Goal_Position"         , 4};
-  item[40] = {120, "Realtime_Tick"         , 2};
-  item[41] = {122, "Moving"                , 1};
-  item[42] = {123, "Moving_Status"         , 1};
-  item[43] = {124, "Present_PWM"           , 2};
-  item[44] = {126, "Present_Current"       , 2};
-  item[45] = {128, "Present_Velocity"      , 4};
-  item[46] = {132, "Present_Position"      , 4};
-  item[47] = {136, "Velocity_Trajectory"   , 4};
-  item[48] = {140, "Position_Trajectory"   , 4};
-  item[49] = {144, "Present_Input_Voltage" , 2};
-  item[50] = {146, "Present_Temperature"   , 1};
-
-  the_number_of_item = 51;
-#endif  
-}
 
 static void setXHInfo()
 {
@@ -1003,146 +773,110 @@ static void setXHInfo()
   model_info.max_radian = 3.14159265;
 }
 
-static void setPROItem()
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {7  , "ID"                    , 1};
-  item[1]  = {8  , "Baud_Rate"             , 1};
-  item[2]  = {11 , "Operating_Mode"        , 1};
+//---------------------------------------------------------
+// PRO - (num == PRO_L42_10_S300_R)
+//---------------------------------------------------------
+static const ControlTableItem items_PRO[] {
+    {0  , "Model_Number"          , 2},
+    {6  , "Firmware_Version"      , 1},
+    {7  , "ID"                    , 1},
+    {8  , "Baud_Rate"             , 1},
+    {9  , "Return_Delay_Time"     , 1},
+    {11 , "Operating_Mode"        , 1},
+    {17 , "Moving_Threshold"      , 4},
+    {21 , "Temperature_Limit"     , 1},
+    {22 , "Max_Voltage_Limit"     , 2},
+    {24 , "Min_Voltage_Limit"     , 2},
+    {26 , "Acceleration_Limit"    , 4},
+    {30 , "Torque_Limit"          , 2},
+    {32 , "Velocity_Limit"        , 4},
+    {36 , "Max_Position_Limit"    , 4},
+    {40 , "Min_Position_Limit"    , 4},
+    {44 , "External_Port_Mode_1"  , 1},
+    {45 , "External_Port_Mode_2"  , 1},
+    {46 , "External_Port_Mode_3"  , 1},
+    {47 , "External_Port_Mode_4"  , 1},
+    {48 , "Shutdown"              , 1},
 
-  item[3]  = {562, "Torque_Enable"         , 1};
-  item[4]  = {563, "LED_RED"               , 1};
-  item[5]  = {596, "Goal_Position"         , 4};
-  item[6]  = {600, "Goal_Velocity"         , 4};
-  item[7]  = {604, "Goal_Torque"           , 2};
-  item[8]  = {606, "Goal_Acceleration"     , 4};
-  item[9]  = {610, "Moving"                , 1};
-  item[10] = {611, "Present_Position"      , 4};
-  item[11] = {615, "Present_Velocity"      , 4};
-  item[12] = {621, "Present_Current"       , 2};
+    {562, "Torque_Enable"         , 1},
+    {563, "LED_RED"               , 1},
+    {564, "LED_GREEN"             , 1},
+    {565, "LED_BLUE"              , 1},
+    {586, "Velocity_I_Gain"       , 2},
+    {588, "Velocity_P_Gain"       , 2},
+    {594, "Position_P_Gain"       , 2},
+    {596, "Goal_Position"         , 4},
+    {600, "Goal_Velocity"         , 4},
+    {604, "Goal_Torque"           , 2},
+    {606, "Goal_Acceleration"     , 4},
+    {610, "Moving"                , 1},
+    {611, "Present_Position"      , 4},
+    {615, "Present_Velocity"      , 4},
+    {621, "Present_Current"       , 2},
+    {623, "Present_Input_Voltage" , 2},
+    {625, "Present_Temperature"   , 1},
+    {626, "External_Port_Mode_1"  , 2},
+    {628, "External_Port_Mode_2"  , 2},
+    {630, "External_Port_Mode_3"  , 2},
+    {632, "External_Port_Mode_4"  , 2},
+    {890, "Registered_Instruction", 1},
+    {891, "Status_Return_Level"   , 1},
+    {892, "Hardware_Error_Status" , 1} };
 
-  the_number_of_item = 13;
-#else
-  item[0]  = {0  , "Model_Number"          , 2};
-  item[1]  = {6  , "Firmware_Version"      , 1};
-  item[2]  = {7  , "ID"                    , 1};
-  item[3]  = {8  , "Baud_Rate"             , 1};
-  item[4]  = {9  , "Return_Delay_Time"     , 1};
-  item[5]  = {11 , "Operating_Mode"        , 1};
-  item[6]  = {17 , "Moving_Threshold"      , 4};
-  item[7]  = {21 , "Temperature_Limit"     , 1};
-  item[8]  = {22 , "Max_Voltage_Limit"     , 2};
-  item[9]  = {24 , "Min_Voltage_Limit"     , 2};
-  item[10] = {26 , "Acceleration_Limit"    , 4};
-  item[11] = {30 , "Torque_Limit"          , 2};
-  item[12] = {32 , "Velocity_Limit"        , 4};
-  item[13] = {36 , "Max_Position_Limit"    , 4};
-  item[14] = {40 , "Min_Position_Limit"    , 4};
-  item[15] = {44 , "External_Port_Mode_1"  , 1};
-  item[16] = {45 , "External_Port_Mode_2"  , 1};
-  item[17] = {46 , "External_Port_Mode_3"  , 1};
-  item[18] = {47 , "External_Port_Mode_4"  , 1};
-  item[19] = {48 , "Shutdown"              , 1};
+#define COUNT_PRO_ITEMS (sizeof(items_PRO)/sizeof(items_PRO[0]))
 
-  item[20] = {562, "Torque_Enable"         , 1};
-  item[21] = {563, "LED_RED"               , 1};
-  item[22] = {564, "LED_GREEN"             , 1};
-  item[23] = {565, "LED_BLUE"              , 1};
-  item[24] = {586, "Velocity_I_Gain"       , 2};
-  item[25] = {588, "Velocity_P_Gain"       , 2};
-  item[26] = {594, "Position_P_Gain"       , 2};
-  item[27] = {596, "Goal_Position"         , 4};
-  item[28] = {600, "Goal_Velocity"         , 4};
-  item[29] = {604, "Goal_Torque"           , 2};
-  item[30] = {606, "Goal_Acceleration"     , 4};
-  item[31] = {610, "Moving"                , 1};
-  item[32] = {611, "Present_Position"      , 4};
-  item[33] = {615, "Present_Velocity"      , 4};
-  item[34] = {621, "Present_Current"       , 2};
-  item[35] = {623, "Present_Input_Voltage" , 2};
-  item[36] = {625, "Present_Temperature"   , 1};
-  item[37] = {626, "External_Port_Mode_1"  , 2};
-  item[38] = {628, "External_Port_Mode_2"  , 2};
-  item[39] = {630, "External_Port_Mode_3"  , 2};
-  item[40] = {632, "External_Port_Mode_4"  , 2};
-  item[41] = {890, "Registered_Instruction", 1};
-  item[42] = {891, "Status_Return_Level"   , 1};
-  item[43] = {892, "Hardware_Error_Status" , 1};
+//---------------------------------------------------------
+// EXT PRO - All Other Pros...
+//---------------------------------------------------------
+static const ControlTableItem items_EXTPRO[] {
+    {0  , "Model_Number"          , 2},
+    {6  , "Firmware_Version"      , 1},
+    {7  , "ID"                    , 1},
+    {8  , "Baud_Rate"             , 1},
+    {9  , "Return_Delay_Time"     , 1},
+    {11 , "Operating_Mode"        , 1},
+    {13 , "Homing_Offset"         , 4},
+    {17 , "Moving_Threshold"      , 4},
+    {21 , "Temperature_Limit"     , 1},
+    {22 , "Max_Voltage_Limit"     , 2},
+    {24 , "Min_Voltage_Limit"     , 2},
+    {26 , "Acceleration_Limit"    , 4},
+    {30 , "Torque_Limit"          , 2},
+    {32 , "Velocity_Limit"        , 4},
+    {36 , "Max_Position_Limit"    , 4},
+    {40 , "Min_Position_Limit"    , 4},
+    {44 , "External_Port_Mode_1"  , 1},
+    {45 , "External_Port_Mode_2"  , 1},
+    {46 , "External_Port_Mode_3"  , 1},
+    {47 , "External_Port_Mode_4"  , 1},
+    {48 , "Shutdown"              , 1},
 
-  the_number_of_item = 44;
-#endif  
-}
+    {562, "Torque_Enable"         , 1},
+    {563, "LED_RED"               , 1},
+    {564, "LED_GREEN"             , 1},
+    {565, "LED_BLUE"              , 1},
+    {586, "Velocity_I_Gain"       , 2},
+    {588, "Velocity_P_Gain"       , 2},
+    {594, "Position_P_Gain"       , 2},
+    {596, "Goal_Position"         , 4},
+    {600, "Goal_Velocity"         , 4},
+    {604, "Goal_Torque"           , 2},
+    {606, "Goal_Acceleration"     , 4},
+    {610, "Moving"                , 1},
+    {611, "Present_Position"      , 4},
+    {615, "Present_Velocity"      , 4},
+    {621, "Present_Current"       , 2},
+    {623, "Present_Input_Voltage" , 2},
+    {625, "Present_Temperature"   , 1},
+    {626, "External_Port_Mode_1"  , 2},
+    {628, "External_Port_Mode_2"  , 2},
+    {630, "External_Port_Mode_3"  , 2},
+    {632, "External_Port_Mode_4"  , 2},
+    {890, "Registered_Instruction", 1},
+    {891, "Status_Return_Level"   , 1},
+    {892, "Hardware_Error_Status" , 1} };
 
-static void setExtPROItem()
-{
-#if defined(__OPENCR__) || defined(__OPENCM904__)
-  item[0]  = {7  , "ID"                    , 1};
-  item[1]  = {8  , "Baud_Rate"             , 1};
-  item[2]  = {11 , "Operating_Mode"        , 1};
-
-  item[3]  = {562, "Torque_Enable"         , 1};
-  item[4]  = {563, "LED_RED"               , 1};
-  item[5]  = {596, "Goal_Position"         , 4};
-  item[6]  = {600, "Goal_Velocity"         , 4};
-  item[7]  = {604, "Goal_Torque"           , 2};
-  item[8]  = {606, "Goal_Acceleration"     , 4};
-  item[9]  = {610, "Moving"                , 1};
-  item[10] = {611, "Present_Position"      , 4};
-  item[11] = {615, "Present_Velocity"      , 4};
-  item[12] = {621, "Present_Current"       , 2};
-
-  the_number_of_item = 13;
-#else
-  item[0]  = {0  , "Model_Number"          , 2};
-  item[1]  = {6  , "Firmware_Version"      , 1};
-  item[2]  = {7  , "ID"                    , 1};
-  item[3]  = {8  , "Baud_Rate"             , 1};
-  item[4]  = {9  , "Return_Delay_Time"     , 1};
-  item[5]  = {11 , "Operating_Mode"        , 1};
-  item[6]  = {13 , "Homing_Offset"         , 4};
-  item[7]  = {17 , "Moving_Threshold"      , 4};
-  item[8]  = {21 , "Temperature_Limit"     , 1};
-  item[9]  = {22 , "Max_Voltage_Limit"     , 2};
-  item[10] = {24 , "Min_Voltage_Limit"     , 2};
-  item[11] = {26 , "Acceleration_Limit"    , 4};
-  item[12] = {30 , "Torque_Limit"          , 2};
-  item[13] = {32 , "Velocity_Limit"        , 4};
-  item[14] = {36 , "Max_Position_Limit"    , 4};
-  item[15] = {40 , "Min_Position_Limit"    , 4};
-  item[16] = {44 , "External_Port_Mode_1"  , 1};
-  item[17] = {45 , "External_Port_Mode_2"  , 1};
-  item[18] = {46 , "External_Port_Mode_3"  , 1};
-  item[19] = {47 , "External_Port_Mode_4"  , 1};
-  item[20] = {48 , "Shutdown"              , 1};
-
-  item[20] = {562, "Torque_Enable"         , 1};
-  item[21] = {563, "LED_RED"               , 1};
-  item[22] = {564, "LED_GREEN"             , 1};
-  item[23] = {565, "LED_BLUE"              , 1};
-  item[24] = {586, "Velocity_I_Gain"       , 2};
-  item[25] = {588, "Velocity_P_Gain"       , 2};
-  item[26] = {594, "Position_P_Gain"       , 2};
-  item[27] = {596, "Goal_Position"         , 4};
-  item[28] = {600, "Goal_Velocity"         , 4};
-  item[29] = {604, "Goal_Torque"           , 2};
-  item[30] = {606, "Goal_Acceleration"     , 4};
-  item[31] = {610, "Moving"                , 1};
-  item[32] = {611, "Present_Position"      , 4};
-  item[33] = {615, "Present_Velocity"      , 4};
-  item[34] = {621, "Present_Current"       , 2};
-  item[35] = {623, "Present_Input_Voltage" , 2};
-  item[36] = {625, "Present_Temperature"   , 1};
-  item[37] = {626, "External_Port_Mode_1"  , 2};
-  item[38] = {628, "External_Port_Mode_2"  , 2};
-  item[39] = {630, "External_Port_Mode_3"  , 2};
-  item[40] = {632, "External_Port_Mode_4"  , 2};
-  item[41] = {890, "Registered_Instruction", 1};
-  item[42] = {891, "Status_Return_Level"   , 1};
-  item[43] = {892, "Hardware_Error_Status" , 1};
-
-  the_number_of_item = 44;
-#endif  
-}
+#define COUNT_EXTPRO_ITEMS (sizeof(items_EXTPRO)/sizeof(items_EXTPRO[0]))
 
 static void setPROInfo(uint16_t model_number)
 {
@@ -1207,74 +941,96 @@ static void setPROInfo(uint16_t model_number)
   model_info.max_radian                      =  3.14159265;
 }
 
-ControlTableItem* getConrolTableItem(uint16_t model_number)
+
+//=========================================================
+// Get Servo control table for the specified servo type
+//=========================================================
+const ControlTableItem* getConrolTableItem(uint16_t model_number)
 {
   uint16_t num = model_number;
 
+  const ControlTableItem  *items;
+
   if (num == AX_12A || num == AX_12W || num == AX_18A)
   {
-    setAXItem();
+    items = items_AX;
+    the_number_of_item = COUNT_AX_ITEMS;
   }
   else if (num == RX_10 || num == RX_24F || num == RX_28 || num == RX_64)
   {
-    setRXItem();
+    items = items_RX;
+    the_number_of_item = COUNT_RX_ITEMS;
   }
   else if (num == EX_106)
   {
-    setEXItem();
+    items = items_EX;
+    the_number_of_item = COUNT_EX_ITEMS;
   }
   else if (num == MX_12W || num == MX_28)
   {
-    setMXItem();
+    items = items_MX;
+    the_number_of_item = COUNT_MX_ITEMS;
   }
   else if (num == MX_64 || num == MX_106)
   {
-    setExtMXItem();
+    items = items_EXTMX;
+    the_number_of_item = COUNT_EXTMX_ITEMS;
   }
   else if (num == MX_28_2)
   {
-    setMX2Item();
+    items = items_MX2;
+    the_number_of_item = COUNT_MX2_ITEMS;
   }
   else if (num == MX_64_2 || num == MX_106_2)
   {
-    setExtMX2Item();
+    items = items_EXTMX2;
+    the_number_of_item = COUNT_EXTMX2_ITEMS;
   }
   else if (num == XL_320)
   {
-    setXL320Item();
+    items = items_XL320;
+    the_number_of_item = COUNT_XL320_ITEMS;
   }
   else if (num == XL430_W250)
   {
-    setXLItem();
+    items = items_XL;
+    the_number_of_item = COUNT_XL_ITEMS;
   }
   else if (num == XM430_W210 || num == XM430_W350)
   {
-    setXMItem();
+    items = items_XM;
+    the_number_of_item = COUNT_XM_ITEMS;
   }
   else if (num == XM540_W150 || num == XM540_W270)
   {
-    setExtXMItem();
+    items = items_EXTXM;
+    the_number_of_item = COUNT_EXTXM_ITEMS;
   }
   else if (num == XH430_V210 || num == XH430_V350 || num == XH430_W210 || num == XH430_W350)
   {
-    setXHItem();
+    items = items_XH;
+    the_number_of_item = COUNT_XH_ITEMS;
   }
   else if (num == PRO_L54_30_S400_R || num == PRO_L54_30_S500_R  || num == PRO_L54_50_S290_R || num == PRO_L54_50_S500_R ||
            num == PRO_M42_10_S260_R || num == PRO_M54_40_S250_R  || num == PRO_M54_60_S250_R || 
            num == PRO_H42_20_S300_R || num == PRO_H54_100_S500_R || num == PRO_H54_200_S500_R)
   {
-    setExtPROItem();
+    items = items_EXTPRO;
+    the_number_of_item = COUNT_EXTPRO_ITEMS;
   }
   else if (num == PRO_L42_10_S300_R)
   {
-    setPROItem();
+    items = items_PRO;
+    the_number_of_item = COUNT_PRO_ITEMS;
   }
   else
   {
-    setXMItem();
+    // default to MX...
+    items = items_MX;
+    the_number_of_item = COUNT_MX_ITEMS;
   }
 
-  return item;
+  return items;
 }
 
 ModelInfo* getModelInfo(uint16_t model_number)

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/src/dynamixel_workbench_toolbox/dynamixel_tool.cpp
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/src/dynamixel_workbench_toolbox/dynamixel_tool.cpp
@@ -397,8 +397,8 @@ const ControlTableItem* DynamixelTool::getControlItem(const char* item_name)
     getControlItem("Present_Speed");
   else if (!strncmp(item_name, "Present_Speed", strlen("Present_Speed")))
     getControlItem("Present_Velocity");
-  else 
-    return NULL;
+
+  return NULL;
 }
 
 const ControlTableItem* DynamixelTool::getControlItemPtr(void)

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/src/dynamixel_workbench_toolbox/dynamixel_tool.cpp
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/src/dynamixel_workbench_toolbox/dynamixel_tool.cpp
@@ -151,10 +151,6 @@ void DynamixelTool::setControlTable(uint16_t model_number)
   the_number_of_item_ = getTheNumberOfControlItem();
   info_ptr_           = getModelInfo(model_number);
 
-  for (int index = 0; index < the_number_of_item_; index++)
-    item_[index] = item_ptr_[index];
-
-
   info_.velocity_to_value_ratio         = info_ptr_->velocity_to_value_ratio;
   info_.torque_to_current_value_ratio   = info_ptr_->torque_to_current_value_ratio;
 
@@ -380,17 +376,17 @@ uint8_t DynamixelTool::getTheNumberOfItem(void)
   return the_number_of_item_;
 }
 
-ControlTableItem* DynamixelTool::getControlItem(const char* item_name)
+const ControlTableItem* DynamixelTool::getControlItem(const char* item_name)
 {
-  static ControlTableItem* cti;    
+  static const ControlTableItem* cti = item_ptr_;    // Why is this static? Not to allocate on stack?
 
   for (int num = 0; num < the_number_of_item_; num++)
   {
-    if (!strncmp(item_name, item_[num].item_name, strlen(item_[num].item_name)))
+    if (!strncmp(item_name, cti->item_name, strlen(cti->item_name)))
     {
-      cti = &item_[num];
       return cti;
     }
+    cti++;
   }
 
   if (!strncmp(item_name, "Moving_Speed", strlen("Moving_Speed")))
@@ -401,9 +397,11 @@ ControlTableItem* DynamixelTool::getControlItem(const char* item_name)
     getControlItem("Present_Speed");
   else if (!strncmp(item_name, "Present_Speed", strlen("Present_Speed")))
     getControlItem("Present_Velocity");
+  else 
+    return NULL;
 }
 
-ControlTableItem* DynamixelTool::getControlItemPtr(void)
+const ControlTableItem* DynamixelTool::getControlItemPtr(void)
 {
   return item_ptr_;
 }

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/src/dynamixel_workbench_toolbox/dynamixel_tool.cpp
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/src/dynamixel_workbench_toolbox/dynamixel_tool.cpp
@@ -378,8 +378,7 @@ uint8_t DynamixelTool::getTheNumberOfItem(void)
 
 const ControlTableItem* DynamixelTool::getControlItem(const char* item_name)
 {
-  static const ControlTableItem* cti = item_ptr_;    // Why is this static? Not to allocate on stack?
-
+  const ControlTableItem* cti = item_ptr_;  
   for (int num = 0; num < the_number_of_item_; num++)
   {
     if (!strncmp(item_name, cti->item_name, strlen(cti->item_name)))

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/src/dynamixel_workbench_toolbox/dynamixel_workbench.cpp
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/src/dynamixel_workbench_toolbox/dynamixel_workbench.cpp
@@ -388,6 +388,7 @@ int32_t DynamixelWorkbench::itemRead(uint8_t id, const char* item_name)
 
   if (driver_.readRegister(id, item_name, &data))
     return data;
+  return 0; // Should decide on error value
 }
 
 int32_t  DynamixelWorkbench::itemRead(uint8_t id, uint16_t addr, uint8_t length)
@@ -396,6 +397,7 @@ int32_t  DynamixelWorkbench::itemRead(uint8_t id, uint16_t addr, uint8_t length)
 
   if (driver_.readRegister(id, addr, length, &data))
     return data; 
+  return 0; // Should decide on error value
 }
 
 int32_t* DynamixelWorkbench::syncRead(const char *item_name)
@@ -403,6 +405,7 @@ int32_t* DynamixelWorkbench::syncRead(const char *item_name)
   static int32_t data[16];
   if (driver_.syncRead(item_name, data))
     return data;
+  return 0; // Should decide on error value
 }
 
 int32_t DynamixelWorkbench::bulkRead(uint8_t id, const char* item_name)
@@ -410,6 +413,7 @@ int32_t DynamixelWorkbench::bulkRead(uint8_t id, const char* item_name)
   static int32_t data;
   if (driver_.bulkRead(id, item_name, &data))
     return data;
+  return 0; // Should decide on error value
 }
 
 void DynamixelWorkbench::addSyncWrite(const char* item_name)

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/src/dynamixel_workbench_toolbox/dynamixel_workbench.cpp
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/src/dynamixel_workbench_toolbox/dynamixel_workbench.cpp
@@ -622,3 +622,13 @@ void DynamixelWorkbench::millis(uint16_t msec)
     usleep(1000*msec);
 #endif
 }
+
+ControlTableItem* DynamixelWorkbench::getControlItemPtr(uint8_t id)
+{
+  return driver_.getControlItemPtr(id);
+}
+
+uint8_t DynamixelWorkbench::getTheNumberOfItem(uint8_t id)
+{
+  return driver_.getTheNumberOfItem(id);
+}

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/src/dynamixel_workbench_toolbox/dynamixel_workbench.cpp
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/src/dynamixel_workbench_toolbox/dynamixel_workbench.cpp
@@ -623,12 +623,12 @@ void DynamixelWorkbench::millis(uint16_t msec)
 #endif
 }
 
-ControlTableItem* DynamixelWorkbench::getControlItemPtr(uint8_t id)
+const ControlTableItem* DynamixelWorkbench::getControlItemPtr(uint8_t id)
 {
   return driver_.getControlItemPtr(id);
 }
 
-uint8_t DynamixelWorkbench::getTheNumberOfItem(uint8_t id)
+uint8_t DynamixelWorkbench::getControlItemCount(uint8_t id)
 {
   return driver_.getTheNumberOfItem(id);
 }

--- a/arduino/opencr_arduino/opencr/libraries/OpenCR/examples/08. DynamixelWorkbench/s_Monitor/s_Monitor.ino
+++ b/arduino/opencr_arduino/opencr/libraries/OpenCR/examples/08. DynamixelWorkbench/s_Monitor/s_Monitor.ino
@@ -1,17 +1,17 @@
 /*******************************************************************************
-* Copyright 2016 ROBOTIS CO., LTD.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
+  Copyright 2016 ROBOTIS CO., LTD.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 *******************************************************************************/
 
 /* Authors: Taehun Lim (Darby) */
@@ -19,13 +19,14 @@
 #include <DynamixelWorkbench.h>
 
 #if defined(__OPENCM904__)
-  #define DEVICE_NAME "3" //Dynamixel on Serial3(USART3)  <-OpenCM 485EXP
+#define DEVICE_NAME "3" //Dynamixel on Serial3(USART3)  <-OpenCM 485EXP
 #elif defined(__OPENCR__)
-  #define DEVICE_NAME ""
-#endif   
+#define DEVICE_NAME ""
+#endif
 
 #define STRING_BUF_NUM 64
 String cmd[STRING_BUF_NUM];
+int cmd_string_cnt;
 
 DynamixelWorkbench dxl_wb;
 uint8_t get_id[16];
@@ -33,18 +34,18 @@ uint8_t scan_cnt = 0;
 uint8_t ping_cnt = 0;
 
 bool isAvailableID(uint8_t id);
-void split(String data, char separator, String* temp);
+int split(String data, char separator, String* temp);
 void printInst();
 
-void setup() 
+void setup()
 {
   Serial.begin(57600);
-  while(!Serial); // Open a Serial Monitor  
+  while (!Serial); // Open a Serial Monitor
 
   printInst();
 }
 
-void loop() 
+void loop()
 {
   if (Serial.available())
   {
@@ -53,7 +54,7 @@ void loop()
 
     read_string.trim();
 
-    split(read_string, ' ', cmd);
+    cmd_string_cnt = split(read_string, ' ', cmd);
 
     if (cmd[0] == "help")
     {
@@ -61,21 +62,19 @@ void loop()
     }
     else if (cmd[0] == "begin")
     {
-      if (cmd[1] == '\0')
-        cmd[1] = String("57600");
-
-      uint32_t baud = cmd[1].toInt();
+      uint32_t baud = 57600;
+      if (cmd_string_cnt > 1)
+        baud = cmd[1].toInt();
       if (dxl_wb.begin(DEVICE_NAME, baud))
         Serial.println("Succeed to begin(" + String(baud) + ")");
       else
         Serial.println("Failed to begin");
     }
     else if (cmd[0] == "scan")
-    { 
-      if (cmd[1] == '\0')
-        cmd[1] = String("100");
-
-      uint8_t range = cmd[1].toInt();
+    {
+      uint8_t range = 100;  // default
+      if (cmd_string_cnt > 1)
+        range = cmd[1].toInt();
       dxl_wb.scan(get_id, &scan_cnt, range);
 
       if (scan_cnt == 0)
@@ -89,10 +88,10 @@ void loop()
     }
     else if (cmd[0] == "ping")
     {
-      if (cmd[1] == '\0')
-        cmd[1] = String("1");
+      get_id[ping_cnt] = 1; // default to 1
+      if (cmd_string_cnt > 1)
+        get_id[ping_cnt] = cmd[1].toInt();
 
-      get_id[ping_cnt] = cmd[1].toInt();
       uint16_t model_number = 0;
 
       if (dxl_wb.ping(get_id[ping_cnt], &model_number))
@@ -105,7 +104,40 @@ void loop()
     }
     else if (isAvailableID(cmd[1].toInt()))
     {
-      if (cmd[0] == "id")
+      if (cmd[0] == "info")
+      {
+        // Lets loop through all of the information for this servo...
+        uint8_t id     = cmd[1].toInt();
+
+        // first print model number stuff
+        uint16_t model_number = 0;
+        ControlTableItem *cti =  dxl_wb.getControlItemPtr(id);
+        uint8_t cti_count = dxl_wb.getTheNumberOfItem(id);
+        if (cti)
+        {
+          if (dxl_wb.ping(id, &model_number))
+          {
+            Serial.print("Servo Info for id : ");
+            Serial.print(id, DEC);
+            Serial.print(" model_number : ");
+            Serial.print(model_number, DEC);
+            Serial.print("(");
+            Serial.print(dxl_wb.getModelName(id));
+            Serial.println(")");
+          }
+          while (cti_count--)
+          {
+            Serial.print("  ");
+            Serial.print(cti->item_name);
+            Serial.print(": ");
+            int32_t value = dxl_wb.itemRead(id, cti->item_name);
+            Serial.println(value, DEC);
+            cti++;
+          }
+        }
+      }
+
+      else if (cmd[0] == "id")
       {
         uint8_t id     = cmd[1].toInt();
         uint8_t new_id = cmd[2].toInt();
@@ -145,7 +177,7 @@ void loop()
 
         dxl_wb.jointMode(id);
         if (dxl_wb.goalPosition(id, goal))
-        Serial.println("Succeed to joint command!!");
+          Serial.println("Succeed to joint command!!");
         else
           Serial.println("Failed");
 
@@ -163,11 +195,11 @@ void loop()
       }
       else if (cmd[0] == "write")
       {
-        uint8_t id = cmd[1].toInt();      
-        int32_t value = cmd[3].toInt(); 
+        uint8_t id = cmd[1].toInt();
+        int32_t value = cmd[3].toInt();
 
         if (dxl_wb.itemWrite(id, cmd[2].c_str(), value))
-        {        
+        {
           Serial.println("Succeed to write command!!");
         }
         else
@@ -176,7 +208,7 @@ void loop()
       else if (cmd[0] == "read")
       {
         uint8_t id = cmd[1].toInt();
-              
+
         int32_t value = dxl_wb.itemRead(id, cmd[2].c_str());
 
         Serial.println("read data : " + String(value));
@@ -199,42 +231,48 @@ void loop()
         else
           Serial.println("Failed to reset");
       }
-      else 
+      else
       {
         Serial.println("Wrong command");
       }
     }
-    else 
+    else
     {
       Serial.println("Please check ID");
     }
   }
 }
 
-void split(String data, char separator, String* temp)
+int split(String data, char separator, String* temp)
 {
-	int cnt = 0;
-	int get_index = 0;
+  int cnt = 0;
+  int get_index = 0;
 
   String copy = data;
-  
-	while(true)
-	{
-		get_index = copy.indexOf(separator);
 
-		if(-1 != get_index)
-		{
-			temp[cnt] = copy.substring(0, get_index);
+  // Clear out anything in the first 4 strings...
+  temp[0] = "";
+  temp[1] = "";
+  temp[2] = "";
+  temp[3] = "";
 
-			copy = copy.substring(get_index + 1);
-		}
-		else
-		{
-      temp[cnt] = copy.substring(0, copy.length());
-			break;
-		}
-		++cnt;
-	}
+  while (true)
+  {
+    get_index = copy.indexOf(separator);
+
+    if (-1 != get_index)
+    {
+      temp[cnt++] = copy.substring(0, get_index);
+
+      copy = copy.substring(get_index + 1);
+    }
+    else
+    {
+      temp[cnt++] = copy.substring(0, copy.length());
+      break;
+    }
+  }
+  return cnt;
 }
 
 bool isAvailableID(uint8_t id)
@@ -257,6 +295,7 @@ void printInst(void)
   Serial.println("begin  (BAUD)");
   Serial.println("scan   (RANGE)");
   Serial.println("ping   (ID)");
+  Serial.println("info   (ID)");
   Serial.println("id     (ID) (NEW_ID)");
   Serial.println("baud   (ID) (NEW_BAUD)");
   Serial.println("torque (ID) (VALUE)");

--- a/arduino/opencr_arduino/opencr/libraries/OpenCR/examples/08. DynamixelWorkbench/s_Monitor/s_Monitor.ino
+++ b/arduino/opencr_arduino/opencr/libraries/OpenCR/examples/08. DynamixelWorkbench/s_Monitor/s_Monitor.ino
@@ -111,8 +111,8 @@ void loop()
 
         // first print model number stuff
         uint16_t model_number = 0;
-        ControlTableItem *cti =  dxl_wb.getControlItemPtr(id);
-        uint8_t cti_count = dxl_wb.getTheNumberOfItem(id);
+        const ControlTableItem *cti =  dxl_wb.getControlItemPtr(id);
+        uint8_t cti_count = dxl_wb.getControlItemCount(id);
         if (cti)
         {
           if (dxl_wb.ping(id, &model_number))

--- a/arduino/opencr_arduino/opencr/platform.txt
+++ b/arduino/opencr_arduino/opencr/platform.txt
@@ -21,13 +21,13 @@ compiler.warning_flags.all=-Wall -Wextra -DDEBUG_LEVEL=DEBUG_ALL
 # ----------------------
 compiler.path={runtime.tools.opencr_gcc.path}/bin/
 compiler.c.cmd=arm-none-eabi-gcc
-compiler.c.flags=-c -g -O2 -std=gnu99 -mfloat-abi=softfp -mfpu=fpv5-sp-d16 {compiler.warning_flags} -MMD -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -DBOARD_{build.variant}
+compiler.c.flags=-c -g -O2 -std=gnu11 -mfloat-abi=softfp -mfpu=fpv5-sp-d16 {compiler.warning_flags} -MMD -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -DBOARD_{build.variant}
 compiler.c.elf.cmd=arm-none-eabi-g++
 compiler.c.elf.flags=-Os -Wl,--gc-sections
 compiler.S.cmd=arm-none-eabi-gcc
 compiler.S.flags=-c -g -x assembler-with-cpp -MMD
 compiler.cpp.cmd=arm-none-eabi-g++
-compiler.cpp.flags=-c -g -O2 -mfloat-abi=softfp -mfpu=fpv5-sp-d16 {compiler.warning_flags} -MMD -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -DBOARD_{build.variant}
+compiler.cpp.flags=-c -g -O2 -std=gnu++11 -mfloat-abi=softfp -mfpu=fpv5-sp-d16 {compiler.warning_flags} -MMD -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -DBOARD_{build.variant}
 compiler.ar.cmd=arm-none-eabi-ar
 compiler.ar.flags=rcs
 compiler.objcopy.cmd=arm-none-eabi-objcopy


### PR DESCRIPTION
@OpusK and @routiful - My guess is more for @routiful 

This is sort of a reasonably major change to the items info stuff and how it works.

Before there was a static item[] table defined that when it sees a new servo with a different type, it fills in this static array with list of name, register, size info, which then the tool object then copied this array into it's own array. 

As memory on the OpenCR and more particular OpenCM9.04 is limited.  They only allowed a sub-set of the items, which has come up many times on forum. 

This update creates static const arrays for each of the servo types.  This leaves all of the memory associated with the list in program memory and does not use up the RAM memory.   So I did it with the full list.  I also removed the array in the tools objects so again saves memory.  Also changed all references to these items to be const.  

I still like the idea of allowing the user see what is a list of valid address names, so started this change in this branch which has the code for the "info" command as mentioned in issue #136 

So far I have only tested with the updated program mentioned in issue #136 
It compiles with several warnings on the OpenCR, which I think we should address (note current released version does as well).

Also if the changes here are accepted, it should also be applied to the OpenCM code base and probably the main Dynamixel Workbench project as well. 

This would also address other issues example from OPenCM9.04: https://github.com/ROBOTIS-GIT/OpenCM9.04/issues/43

Let me know what you think... 
