### PR TITLE
Dynamixel sdk playing with sync read write

### DIFF
--- a/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/include/dynamixel_sdk/group_sync_read.h
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/include/dynamixel_sdk/group_sync_read.h
@@ -54,18 +54,29 @@ class WINDECLSPEC GroupSyncRead
   PortHandler    *port_;
   PacketHandler  *ph_;
 
-  std::vector<uint8_t>            id_list_;
-  std::map<uint8_t, uint8_t* >    data_list_; // <id, data>
-
+  //std::vector<uint8_t>            id_list_;
+  //std::map<uint8_t, uint8_t* >    data_list_; // <id, data>
   bool            last_result_;
-  bool            is_param_changed_;
-  uint8_t        *param_;
+
+  bool            is_user_buffer_;  // did the user setup this buffer?
+  uint8_t         max_ids_;         // Max number of IDs we can handle
+  uint8_t         count_ids_;       // Actual count of ids 
+
+  uint8_t         *param_;           // this will hold our buffer.
   uint16_t        start_address_;
   uint16_t        data_length_;
 
-  void    makeParam();
+  uint8_t *findParam(uint8_t id, bool add_if_not_found);
 
  public:
+  
+  ////////////////////////////////////////////////////////////////////////////////
+  /// @brief - Lets sketches know how many extra bytes per servo to allocate
+  ///  they can add this to number of bytes they write (data_length)
+  // 
+  ////////////////////////////////////////////////////////////////////////////////
+  enum {EXTRA_BYTES_PER_ITEM = 1 };
+
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief The function that Initializes instance for Sync Read
   /// @param port PortHandler instance
@@ -73,12 +84,12 @@ class WINDECLSPEC GroupSyncRead
   /// @param start_address Address of the data for read
   /// @param data_length Length of the data for read
   ////////////////////////////////////////////////////////////////////////////////
-  GroupSyncRead(PortHandler *port, PacketHandler *ph, uint16_t start_address, uint16_t data_length);
+  GroupSyncRead(PortHandler *port, PacketHandler *ph, uint16_t start_address, uint16_t data_length, uint8_t max_ids=16);
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief The function that calls clearParam function to clear the parameter list for Sync Read
   ////////////////////////////////////////////////////////////////////////////////
-  ~GroupSyncRead() { clearParam(); }
+  ~GroupSyncRead();
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief Two part initialization of Sync Read
@@ -89,7 +100,7 @@ class WINDECLSPEC GroupSyncRead
   /// @param start_address Address of the data for read
   /// @param data_length Length of the data for read
   ////////////////////////////////////////////////////////////////////////////////
-  GroupSyncRead(uint16_t start_address, uint16_t data_length);
+  GroupSyncRead(uint16_t start_address, uint16_t data_length, uint8_t max_ids=16);
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief Second part of two part initialization of Sync Read
@@ -102,6 +113,12 @@ class WINDECLSPEC GroupSyncRead
   ////////////////////////////////////////////////////////////////////////////////
   void    init(PortHandler *port, PacketHandler *ph);
 
+  ////////////////////////////////////////////////////////////////////////////////
+  /// @brief setBuffer allows the user to pass in the buffer to use
+  /// @param buffer pointer to data buffer to use
+  /// @param cb size of the buffer in bytes
+  ////////////////////////////////////////////////////////////////////////////////
+  bool  setBuffer(uint8_t *buffer_pointer, uint16_t buffer_size);  
 
 
   ////////////////////////////////////////////////////////////////////////////////

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/include/dynamixel_sdk/group_sync_read.h
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/include/dynamixel_sdk/group_sync_read.h
@@ -59,7 +59,6 @@ class WINDECLSPEC GroupSyncRead
 
   bool            last_result_;
   bool            is_param_changed_;
-
   uint8_t        *param_;
   uint16_t        start_address_;
   uint16_t        data_length_;
@@ -80,6 +79,30 @@ class WINDECLSPEC GroupSyncRead
   /// @brief The function that calls clearParam function to clear the parameter list for Sync Read
   ////////////////////////////////////////////////////////////////////////////////
   ~GroupSyncRead() { clearParam(); }
+
+  ////////////////////////////////////////////////////////////////////////////////
+  /// @brief Two part initialization of Sync Read
+  ///       Needed if you wish to create global objects and not use new...
+  ///       as things like PortHandler and PacketHandler are not initialized yet
+  /// @param port PortHandler instance
+  /// @param ph PacketHandler instance
+  /// @param start_address Address of the data for read
+  /// @param data_length Length of the data for read
+  ////////////////////////////////////////////////////////////////////////////////
+  GroupSyncRead(uint16_t start_address, uint16_t data_length);
+
+  ////////////////////////////////////////////////////////////////////////////////
+  /// @brief Second part of two part initialization of Sync Read
+  ///       Needed if you wish to create global objects and not use new...
+  ///       as things like PortHandler and PacketHandler are not initialized yet
+  /// @param port PortHandler instance
+  /// @param ph PacketHandler instance
+  /// @param start_address Address of the data for read
+  /// @param data_length Length of the data for read
+  ////////////////////////////////////////////////////////////////////////////////
+  void    init(PortHandler *port, PacketHandler *ph);
+
+
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief The function that returns PortHandler instance

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/include/dynamixel_sdk/group_sync_read.h
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/include/dynamixel_sdk/group_sync_read.h
@@ -75,7 +75,7 @@ class WINDECLSPEC GroupSyncRead
   ///  they can add this to number of bytes they write (data_length)
   // 
   ////////////////////////////////////////////////////////////////////////////////
-  enum {EXTRA_BYTES_PER_ITEM = 1 };
+  enum {EXTRA_BYTES_PER_ITEM = 1, DEFAULT_COUNT_MAX_IDS = 16 };
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief The function that Initializes instance for Sync Read
@@ -84,7 +84,8 @@ class WINDECLSPEC GroupSyncRead
   /// @param start_address Address of the data for read
   /// @param data_length Length of the data for read
   ////////////////////////////////////////////////////////////////////////////////
-  GroupSyncRead(PortHandler *port, PacketHandler *ph, uint16_t start_address, uint16_t data_length, uint8_t max_ids=16);
+  GroupSyncRead(PortHandler *port, PacketHandler *ph, uint16_t start_address, uint16_t data_length, 
+      uint8_t max_ids=DEFAULT_COUNT_MAX_IDS);
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief The function that calls clearParam function to clear the parameter list for Sync Read
@@ -100,7 +101,7 @@ class WINDECLSPEC GroupSyncRead
   /// @param start_address Address of the data for read
   /// @param data_length Length of the data for read
   ////////////////////////////////////////////////////////////////////////////////
-  GroupSyncRead(uint16_t start_address, uint16_t data_length, uint8_t max_ids=16);
+  GroupSyncRead(uint16_t start_address, uint16_t data_length, uint8_t max_ids=DEFAULT_COUNT_MAX_IDS);
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief Second part of two part initialization of Sync Read

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/include/dynamixel_sdk/group_sync_write.h
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/include/dynamixel_sdk/group_sync_write.h
@@ -58,6 +58,7 @@ class WINDECLSPEC GroupSyncWrite
   std::map<uint8_t, uint8_t* >    data_list_; // <id, data>
 
   bool            is_param_changed_;
+  bool            is_init_;
 
   uint8_t        *param_;
   uint16_t        start_address_;
@@ -68,12 +69,28 @@ class WINDECLSPEC GroupSyncWrite
  public:
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief The function that Initializes instance for Sync Write
+  ///     Warning don't use this version for global objects, it will crash!
   /// @param port PortHandler instance
   /// @param ph PacketHandler instance
   /// @param start_address Address of the data for write
   /// @param data_length Length of the data for write
   ////////////////////////////////////////////////////////////////////////////////
   GroupSyncWrite(PortHandler *port, PacketHandler *ph, uint16_t start_address, uint16_t data_length);
+
+  ////////////////////////////////////////////////////////////////////////////////
+  /// @brief constructor first part of two part initialize use for global objects
+  /// @param start_address Address of the data for write
+  /// @param data_length Length of the data for write
+  ////////////////////////////////////////////////////////////////////////////////
+  GroupSyncWrite(uint16_t start_address, uint16_t data_length);
+
+  ////////////////////////////////////////////////////////////////////////////////
+  /// @brief Init the second half of two part init
+  /// @param port PortHandler instance
+  /// @param ph PacketHandler instance
+  ////////////////////////////////////////////////////////////////////////////////
+  void    init(PortHandler *port, PacketHandler *ph);
+
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief The function that calls clearParam function to clear the parameter list for Sync Write

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/include/dynamixel_sdk/group_sync_write.h
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/include/dynamixel_sdk/group_sync_write.h
@@ -65,9 +65,17 @@ class WINDECLSPEC GroupSyncWrite
   uint16_t        start_address_;
   uint16_t        data_length_;
 
-  uint8_t *findParam(uint8_t id);
+  uint8_t *findParam(uint8_t id, bool add_if_not_found);
 
  public:
+  
+  ////////////////////////////////////////////////////////////////////////////////
+  /// @brief - Lets sketches know how many extra bytes per servo to allocate
+  ///  they can add this to number of bytes they write (data_length)
+  // 
+  ////////////////////////////////////////////////////////////////////////////////
+  enum {EXTRA_BYTES_PER_ITEM = 1 };
+
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief The function that Initializes instance for Sync Write
   ///     Warning don't use this version for global objects, it will crash!

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/include/dynamixel_sdk/group_sync_write.h
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/include/dynamixel_sdk/group_sync_write.h
@@ -74,7 +74,7 @@ class WINDECLSPEC GroupSyncWrite
   ///  they can add this to number of bytes they write (data_length)
   // 
   ////////////////////////////////////////////////////////////////////////////////
-  enum {EXTRA_BYTES_PER_ITEM = 1 };
+  enum {EXTRA_BYTES_PER_ITEM = 1, DEFAULT_COUNT_MAX_IDS = 16 };
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief The function that Initializes instance for Sync Write
@@ -85,7 +85,8 @@ class WINDECLSPEC GroupSyncWrite
   /// @param data_length Length of the data for write
   /// @param max_ids max number of IDs we will use with this object... 
   ////////////////////////////////////////////////////////////////////////////////
-  GroupSyncWrite(PortHandler *port, PacketHandler *ph, uint16_t start_address, uint16_t data_length, uint8_t max_ids=16);
+  GroupSyncWrite(PortHandler *port, PacketHandler *ph, uint16_t start_address, uint16_t data_length, 
+      uint8_t max_ids=DEFAULT_COUNT_MAX_IDS);
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief constructor first part of two part initialize use for global objects
@@ -93,7 +94,8 @@ class WINDECLSPEC GroupSyncWrite
   /// @param data_length Length of the data for write
   /// @param max_ids max number of IDs we will use with this object... 
   ////////////////////////////////////////////////////////////////////////////////
-  GroupSyncWrite(uint16_t start_address, uint16_t data_length, uint8_t max_ids=16);
+  GroupSyncWrite(uint16_t start_address, uint16_t data_length, 
+      uint8_t max_ids=DEFAULT_COUNT_MAX_IDS);
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief Init the second half of two part init

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/include/dynamixel_sdk/group_sync_write.h
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/include/dynamixel_sdk/group_sync_write.h
@@ -54,17 +54,18 @@ class WINDECLSPEC GroupSyncWrite
   PortHandler    *port_;
   PacketHandler  *ph_;
 
-  std::vector<uint8_t>            id_list_;
-  std::map<uint8_t, uint8_t* >    data_list_; // <id, data>
+  //std::vector<uint8_t>            id_list_;
+  //std::map<uint8_t, uint8_t* >    data_list_; // <id, data>
 
-  bool            is_param_changed_;
-  bool            is_init_;
+  bool            is_user_buffer_;  // did the user setup this buffer?
+  uint8_t         max_ids_;         // Max number of IDs we can handle
+  uint8_t         count_ids_;       // Actual count of ids 
 
-  uint8_t        *param_;
+  uint8_t        *param_;           // this will hold our buffer.
   uint16_t        start_address_;
   uint16_t        data_length_;
 
-  void    makeParam();
+  uint8_t *findParam(uint8_t id);
 
  public:
   ////////////////////////////////////////////////////////////////////////////////
@@ -74,15 +75,17 @@ class WINDECLSPEC GroupSyncWrite
   /// @param ph PacketHandler instance
   /// @param start_address Address of the data for write
   /// @param data_length Length of the data for write
+  /// @param max_ids max number of IDs we will use with this object... 
   ////////////////////////////////////////////////////////////////////////////////
-  GroupSyncWrite(PortHandler *port, PacketHandler *ph, uint16_t start_address, uint16_t data_length);
+  GroupSyncWrite(PortHandler *port, PacketHandler *ph, uint16_t start_address, uint16_t data_length, uint8_t max_ids=16);
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief constructor first part of two part initialize use for global objects
   /// @param start_address Address of the data for write
   /// @param data_length Length of the data for write
+  /// @param max_ids max number of IDs we will use with this object... 
   ////////////////////////////////////////////////////////////////////////////////
-  GroupSyncWrite(uint16_t start_address, uint16_t data_length);
+  GroupSyncWrite(uint16_t start_address, uint16_t data_length, uint8_t max_ids=16);
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief Init the second half of two part init
@@ -91,11 +94,17 @@ class WINDECLSPEC GroupSyncWrite
   ////////////////////////////////////////////////////////////////////////////////
   void    init(PortHandler *port, PacketHandler *ph);
 
+  ////////////////////////////////////////////////////////////////////////////////
+  /// @brief setBuffer allows the user to pass in the buffer to use
+  /// @param buffer pointer to data buffer to use
+  /// @param cb size of the buffer in bytes
+  ////////////////////////////////////////////////////////////////////////////////
+  bool  setBuffer(uint8_t *buffer_pointer, uint16_t buffer_size);  
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief The function that calls clearParam function to clear the parameter list for Sync Write
   ////////////////////////////////////////////////////////////////////////////////
-  ~GroupSyncWrite() { clearParam(); }
+  ~GroupSyncWrite();
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief The function that returns PortHandler instance
@@ -118,6 +127,18 @@ class WINDECLSPEC GroupSyncWrite
   /// @return or true
   ////////////////////////////////////////////////////////////////////////////////
   bool    addParam    (uint8_t id, uint8_t *data);
+
+  ////////////////////////////////////////////////////////////////////////////////
+  /// @brief The function that adds id, start_address, data_length to the Sync Write list
+  /// @param id Dynamixel ID
+  /// @param start_address starting register number
+  /// @param length how many bytes (1, 2, or 4)
+  /// @param data Data for write
+  /// @return false
+  /// @return   when the ID exists already in the list
+  /// @return or true
+  ////////////////////////////////////////////////////////////////////////////////
+  bool    setParam    (uint8_t id, uint16_t address, uint16_t data_length, uint32_t data);
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief The function that removes id from the Sync Write list

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/src/dynamixel_sdk/group_sync_read.cpp
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/src/dynamixel_sdk/group_sync_read.cpp
@@ -72,7 +72,7 @@ void GroupSyncRead::init(PortHandler *port, PacketHandler *ph)
 {
   port_ = port;
   ph_ = ph;
-  Serial.printf("GroupSyncRead::Init called %x %x\n", (uint32_t)port_, (uint32_t)ph_); Serial.flush();
+  //Serial.printf("GroupSyncRead::Init called %x %x\n", (uint32_t)port_, (uint32_t)ph_); Serial.flush();
   clearParam();
 }
 

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/src/dynamixel_sdk/group_sync_read.cpp
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/src/dynamixel_sdk/group_sync_read.cpp
@@ -45,11 +45,14 @@
 
 using namespace dynamixel;
 
-GroupSyncRead::GroupSyncRead(PortHandler *port, PacketHandler *ph, uint16_t start_address, uint16_t data_length)
+GroupSyncRead::GroupSyncRead(PortHandler *port, PacketHandler *ph, 
+      uint16_t start_address, uint16_t data_length, uint8_t max_ids)
   : port_(port),
     ph_(ph),
     last_result_(false),
-    is_param_changed_(false),
+    is_user_buffer_(false),
+    max_ids_(max_ids),
+    count_ids_(0),
     param_(0),
     start_address_(start_address),
     data_length_(data_length)
@@ -57,15 +60,26 @@ GroupSyncRead::GroupSyncRead(PortHandler *port, PacketHandler *ph, uint16_t star
   clearParam();
 }
 
-GroupSyncRead::GroupSyncRead(uint16_t start_address, uint16_t data_length)
+GroupSyncRead::GroupSyncRead(uint16_t start_address, uint16_t data_length, uint8_t max_ids)
   : port_(NULL),
     ph_(NULL),
     last_result_(false),
-    is_param_changed_(false),
+    is_user_buffer_(false),
+    max_ids_(max_ids),
+    count_ids_(0),
     param_(0),
     start_address_(start_address),
     data_length_(data_length)
 {
+}
+
+GroupSyncRead::~GroupSyncRead()
+{
+  if (!is_user_buffer_ && param_)
+  {
+    delete[] param_;
+    param_ = NULL;  // probably not needed
+  }
 }
 
 void GroupSyncRead::init(PortHandler *port, PacketHandler *ph) 
@@ -76,77 +90,113 @@ void GroupSyncRead::init(PortHandler *port, PacketHandler *ph)
   clearParam();
 }
 
-void GroupSyncRead::makeParam()
+bool GroupSyncRead::setBuffer(uint8_t *buffer_pointer, uint16_t buffer_size)
 {
-  if (ph_->getProtocolVersion() == 1.0 || id_list_.size() == 0)
-    return;
-
-  if (param_ != 0)
+  // See if there already was a buffer 
+  if (!is_user_buffer_ && param_)
+  {
     delete[] param_;
-  param_ = 0;
+  }  
+  // User passed in a buffer.
+  param_ = buffer_pointer;
+  count_ids_ = 0; 
+  if (buffer_pointer)
+  {
+    is_user_buffer_ = true;
+    max_ids_ = buffer_size / (data_length_ + EXTRA_BYTES_PER_ITEM);  // calculate how many servos this buffer could service
+    return (max_ids_ > 0);
+  }
+  is_user_buffer_ = false;
+  return true;
+}  
 
-  param_ = new uint8_t[id_list_.size() * 1];  // ID(1)
+// Different than group write as I will keep all of the IDS at the start
+// of this list, also will allocate if necessary... 
+// And will fill in the ID for the caller... 
+uint8_t *GroupSyncRead::findParam(uint8_t id, bool add_if_not_found)
+{
+  if (!param_)
+  {
+    //Serial.println("GroupSyncRead::findParam create buffer");
+    param_ = new uint8_t[max_ids_ * (EXTRA_BYTES_PER_ITEM + data_length_)]; // ID(1) + DATA(data_length)
+    is_user_buffer_ = false;
+    if (!param_)
+      return NULL; 
+    count_ids_ = 0;
+  }
 
-  int idx = 0;
-  for (unsigned int i = 0; i < id_list_.size(); i++)
-    param_[idx++] = id_list_[i];
+
+  uint8_t *pb = param_;
+  for (uint8_t i = 0; i < count_ids_; i++)
+  {
+    if (*pb == id)
+    {
+      // Item was found, now calculate it's buffer location
+      // first part of buffer is setup to store all of the ids, followed
+      // by the data per item
+      return (param_ + max_ids_ + i * data_length_);    
+    }
+    pb++;
+  }
+  // Not found, lets see if there is room for new one
+  if ((count_ids_ >= max_ids_) || !add_if_not_found)
+    return NULL;
+  
+  // Have room, so save away the id and calculate the address
+  param_[count_ids_] = id;
+  count_ids_++; // increment our count
+  return (param_ + max_ids_ + (count_ids_ - 1) * data_length_);
 }
 
 bool GroupSyncRead::addParam(uint8_t id)
 {
 
   // If we don't have packet handler or this is version 1 bail
+  //Serial.printf("GroupSyncRead::addParam %d\n", id);
   if (!ph_ || (ph_->getProtocolVersion() == 1.0))
     return false;
 
-  if (std::find(id_list_.begin(), id_list_.end(), id) != id_list_.end())   // id already exist
+  uint8_t *item_pointer = findParam(id, true);  
+  if (!item_pointer)
+  {
     return false;
+  }
 
-  id_list_.push_back(id);
-  data_list_[id] = new uint8_t[data_length_];
-
-  is_param_changed_   = true;
   return true;
 }
+
 void GroupSyncRead::removeParam(uint8_t id)
 {
-  if (!ph_ || (ph_->getProtocolVersion() == 1.0))
+  if (!ph_ || (ph_->getProtocolVersion() == 1.0) || !param_)
     return;
 
-  std::vector<uint8_t>::iterator it = std::find(id_list_.begin(), id_list_.end(), id);
-  if (it == id_list_.end())    // NOT exist
-    return;
-
-  id_list_.erase(it);
-  delete[] data_list_[id];
-  data_list_.erase(id);
-
-  is_param_changed_   = true;
+  // Warning, I am not worrying about copy data parts back as
+  // bet no one uses this anyway...
+  uint8_t *pb = param_;
+  for (uint8_t i = 0; i < count_ids_; i++)
+  {
+    if (*pb == id)
+    {
+      while (i < (count_ids_ - 1))
+      {
+        param_[i] = param_[i+1];
+        i++;
+      }
+      count_ids_--; // decrement the count
+    }
+  }
 }
 void GroupSyncRead::clearParam()
 {
-  if (!ph_ || ph_->getProtocolVersion() == 1.0 || id_list_.size() == 0)
-    return;
-
-  for (unsigned int i = 0; i < id_list_.size(); i++)
-    delete[] data_list_[id_list_[i]];
-
-  id_list_.clear();
-  data_list_.clear();
-  if (param_ != 0)
-    delete[] param_;
-  param_ = 0;
+  count_ids_ = 0;
 }
 
 int GroupSyncRead::txPacket()
 {
-  if (!ph_ || ph_->getProtocolVersion() == 1.0 || id_list_.size() == 0)
+  if (!ph_ || ph_->getProtocolVersion() == 1.0 || count_ids_ == 0)
     return COMM_NOT_AVAILABLE;
 
-  if (is_param_changed_ == true || param_ == 0)
-    makeParam();
-
-  return ph_->syncReadTx(port_, start_address_, data_length_, param_, (uint16_t)id_list_.size() * 1);
+  return ph_->syncReadTx(port_, start_address_, data_length_, param_, count_ids_);
 }
 
 int GroupSyncRead::rxPacket()
@@ -156,19 +206,21 @@ int GroupSyncRead::rxPacket()
   if (!ph_ || ph_->getProtocolVersion() == 1.0)
     return COMM_NOT_AVAILABLE;
 
-  int cnt            = id_list_.size();
   int result         = COMM_RX_FAIL;
 
-  if (cnt == 0)
+  if (count_ids_ == 0)
     return COMM_NOT_AVAILABLE;
 
-  for (int i = 0; i < cnt; i++)
+  uint8_t *item_buffer_pointer = param_ + max_ids_;  // points to buffer for first item
+  for (int i = 0; i < count_ids_; i++)
   {
-    uint8_t id = id_list_[i];
+    // Not used, wonder if we should verify that we have the right one...
+    //uint8_t id = param_[i];   // Again id list is the first items in our data storage
 
-    result = ph_->readRx(port_, data_length_, data_list_[id]);
+    result = ph_->readRx(port_, data_length_, item_buffer_pointer);
     if (result != COMM_SUCCESS)
       return result;
+    item_buffer_pointer += data_length_;  // point to storage for next item
   }
 
   if (result == COMM_SUCCESS)
@@ -179,6 +231,7 @@ int GroupSyncRead::rxPacket()
 
 int GroupSyncRead::txRxPacket()
 {
+  //Serial.printf("GroupSyncRead::txRxPacket count: %d\n", count_ids_);
   if (!ph_ || ph_->getProtocolVersion() == 1.0)
     return COMM_NOT_AVAILABLE;
 
@@ -193,7 +246,8 @@ int GroupSyncRead::txRxPacket()
 
 bool GroupSyncRead::isAvailable(uint8_t id, uint16_t address, uint16_t data_length)
 {
-  if (!ph_ || ph_->getProtocolVersion() == 1.0 || last_result_ == false || data_list_.find(id) == data_list_.end())
+  //Serial.printf("\nGroupSyncRead(%u %d)::isAvailable %u %u %u ", start_address_, data_length_, id, address, data_length);
+  if (!ph_ || ph_->getProtocolVersion() == 1.0 || last_result_ == false || !findParam(id, false))
     return false;
 
   if (address < start_address_ || start_address_ + data_length_ - data_length < address)
@@ -204,20 +258,23 @@ bool GroupSyncRead::isAvailable(uint8_t id, uint16_t address, uint16_t data_leng
 
 uint32_t GroupSyncRead::getData(uint8_t id, uint16_t address, uint16_t data_length)
 {
+  //Serial.printf("\nGroupSyncRead(%u %d)::getData %u %u %u ", start_address_, data_length_, id, address, data_length);
   if (isAvailable(id, address, data_length) == false)
     return 0;
 
+  uint8_t *item_buffer_pointer = findParam(id, false); // available alredy verified it existed...
+  item_buffer_pointer += (address - start_address_);  // increment up to start of actual field...
   switch(data_length)
   {
     case 1:
-      return data_list_[id][address - start_address_];
+      return item_buffer_pointer[0];
 
     case 2:
-      return DXL_MAKEWORD(data_list_[id][address - start_address_], data_list_[id][address - start_address_ + 1]);
+      return DXL_MAKEWORD(item_buffer_pointer[0], item_buffer_pointer[1]);
 
     case 4:
-      return DXL_MAKEDWORD(DXL_MAKEWORD(data_list_[id][address - start_address_ + 0], data_list_[id][address - start_address_ + 1]),
-                 DXL_MAKEWORD(data_list_[id][address - start_address_ + 2], data_list_[id][address - start_address_ + 3]));
+      return DXL_MAKEDWORD(DXL_MAKEWORD(item_buffer_pointer[0], item_buffer_pointer[1]),
+                DXL_MAKEWORD(item_buffer_pointer[2], item_buffer_pointer[3]));
 
     default:
       return 0;

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/src/dynamixel_sdk/group_sync_write.cpp
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/src/dynamixel_sdk/group_sync_write.cpp
@@ -45,10 +45,13 @@
 
 using namespace dynamixel;
 
-GroupSyncWrite::GroupSyncWrite(PortHandler *port, PacketHandler *ph, uint16_t start_address, uint16_t data_length)
+GroupSyncWrite::GroupSyncWrite(PortHandler *port, PacketHandler *ph, 
+      uint16_t start_address, uint16_t data_length, uint8_t max_ids)
   : port_(port),
     ph_(ph),
-    is_param_changed_(false),
+    is_user_buffer_(false),
+    max_ids_(max_ids),
+    count_ids_(0),
     param_(0),
     start_address_(start_address),
     data_length_(data_length)
@@ -56,126 +59,205 @@ GroupSyncWrite::GroupSyncWrite(PortHandler *port, PacketHandler *ph, uint16_t st
   clearParam();
 }
 
-GroupSyncWrite::GroupSyncWrite(uint16_t start_address, uint16_t data_length)
+GroupSyncWrite::GroupSyncWrite(uint16_t start_address, uint16_t data_length, uint8_t max_ids)
   : port_(NULL),
     ph_(NULL),
-    is_param_changed_(false),
+    is_user_buffer_(false),
+    max_ids_(max_ids),
+    count_ids_(0),
     param_(0),
     start_address_(start_address),
     data_length_(data_length)
 {
+}
+
+GroupSyncWrite::~GroupSyncWrite()
+{
+  if (!is_user_buffer_ && param_)
+  {
+    delete[] param_;
+    param_ = NULL;  // probably not needed
+  }
 }
 
 void GroupSyncWrite::init(PortHandler *port, PacketHandler *ph)
 {
   port_ = port;
   ph_ = ph;
-  Serial.printf("GroupSyncWrite::Init called %x %x\n", (uint32_t)port_, (uint32_t)ph_); Serial.flush();
+  //Serial.printf("GroupSyncWrite::Init called %x %x\n", (uint32_t)port_, (uint32_t)ph_); Serial.flush();
   clearParam();
 }
 
-void GroupSyncWrite::makeParam()
+bool GroupSyncWrite::setBuffer(uint8_t *buffer_pointer, uint16_t buffer_size)
 {
-  if (id_list_.size() == 0) return;
-
-  if (param_ != 0)
-    delete[] param_;
-  param_ = 0;
-
-  param_ = new uint8_t[id_list_.size() * (1 + data_length_)]; // ID(1) + DATA(data_length)
-
-  int idx = 0;
-  for (unsigned int i = 0; i < id_list_.size(); i++)
+  // See if there already was a buffer 
+  if (!is_user_buffer_ && param_)
   {
-    uint8_t id = id_list_[i];
-    if (data_list_[id] == 0)
-      return;
-
-    param_[idx++] = id;
-    for (int c = 0; c < data_length_; c++)
-      param_[idx++] = (data_list_[id])[c];
+    delete[] param_;
+  }  
+  // User passed in a buffer.
+  param_ = buffer_pointer;
+  count_ids_ = 0; 
+  if (buffer_pointer)
+  {
+    is_user_buffer_ = true;
+    max_ids_ = buffer_size / (data_length_ + 1);  // calculate how many servos this buffer could service
+    return (max_ids_ > 0);
   }
+  is_user_buffer_ = false;
+  return true;
+}  
+
+
+uint8_t *GroupSyncWrite::findParam(uint8_t id)
+{
+  if (!param_) return NULL;
+
+  uint8_t *pb = param_;
+  for (uint8_t i = 0; i < count_ids_; i++)
+  {
+    if (*pb == id)
+      return pb + 1;  // return item in Parameter list for this ID
+    pb += (data_length_ + 1); // look at next element
+  }
+  return NULL;  // not found
+
 }
+
 
 bool GroupSyncWrite::addParam(uint8_t id, uint8_t *data)
 {
   if (!ph_)
     return false;
 
-  if (std::find(id_list_.begin(), id_list_.end(), id) != id_list_.end())   // id already exist
-    return false;
+  if (!param_) 
+  {
+    param_ = new uint8_t[max_ids_ * (1 + data_length_)]; // ID(1) + DATA(data_length)
+    is_user_buffer_ = false;
+    if (!param_)
+      return false; 
+  }
 
-  id_list_.push_back(id);
-  data_list_[id]    = new uint8_t[data_length_];
-  for (int c = 0; c < data_length_; c++)
-    data_list_[id][c] = data[c];
+  // 
+  uint8_t *item_pointer = findParam(id);  
+  if (!item_pointer)
+  {
+    if (count_ids_ >= max_ids_)
+      return false;
+    item_pointer = param_ + (data_length_ + 1)*count_ids_;
+    count_ids_++;
+    *item_pointer++ = id; // save away the ID
+  }
 
-  is_param_changed_   = true;
+  for (uint16_t c = 0; c < data_length_; c++)
+  {
+    *item_pointer++ = *data++;
+  }
   return true;
 }
+
+bool GroupSyncWrite::setParam (uint8_t id, uint16_t address, uint16_t data_length, uint32_t data)
+{
+  // Like addParam, but can set a subset and knows about 1 byte 2 byte and 4 byte fields...
+  if (!ph_)
+    return false;
+  //Serial.printf("\nGroupSyncWrite(%u %d)::setParam %u %u %u %d ", start_address_, data_length_, id, address, data_length, data);
+  // make sure address is valid
+  if ((address < start_address_) || ((start_address_ + data_length_ - data_length) < address))
+    return false;
+
+  if (!param_) 
+  {
+    param_ = new uint8_t[max_ids_ * (1 + data_length_)]; // ID(1) + DATA(data_length)
+    is_user_buffer_ = false;
+    if (!param_)
+      return false; 
+  }
+
+  // 
+  uint8_t *item_pointer = findParam(id);  
+  
+  if (!item_pointer)
+  {
+    //Serial.print(" new item ");
+    if (count_ids_ >= max_ids_)
+      return false;
+    item_pointer = param_ + (data_length_ + 1)*count_ids_;
+    count_ids_++;
+    *item_pointer++ = id; // save away the ID
+    if (data_length != data_length_) 
+    {
+      memset(item_pointer, 0, data_length_); // initialize full area
+    }
+  }
+
+  item_pointer += address - start_address_; // start of where we are writing
+  //Serial.println((uint32_t)item_pointer, HEX);
+
+  switch (data_length) 
+  {
+    case 1: 
+      *item_pointer = DXL_LOBYTE(DXL_LOWORD(data));
+      break;
+    case 2:
+      *item_pointer++ = DXL_LOBYTE(DXL_LOWORD(data));
+      *item_pointer =   DXL_HIBYTE(DXL_LOWORD(data));
+      break;
+    case 4:
+      *item_pointer++ = DXL_LOBYTE(DXL_LOWORD(data));
+      *item_pointer++ = DXL_HIBYTE(DXL_LOWORD(data));
+      *item_pointer++ = DXL_LOBYTE(DXL_HIWORD(data));
+      *item_pointer   = DXL_HIBYTE(DXL_HIWORD(data));
+      break;
+    default:
+      return false;
+    }
+
+  return true;
+}
+
 
 void GroupSyncWrite::removeParam(uint8_t id)
 {
   if (!ph_)
     return;
   
-  std::vector<uint8_t>::iterator it = std::find(id_list_.begin(), id_list_.end(), id);
-  if (it == id_list_.end())    // NOT exist
+  uint8_t *item_pointer = findParam(id);  
+  if (!item_pointer)
     return;
 
-  id_list_.erase(it);
-  delete[] data_list_[id];
-  data_list_.erase(id);
+  // copy data down;
+  uint8_t *next_item_pointer = item_pointer += (data_length_ + 1);
 
-  is_param_changed_   = true;
+  uint8_t *end_pointer = param_ + (data_length_ + 1)*count_ids_;
+
+  while (next_item_pointer < end_pointer) 
+  {
+    *item_pointer++ = *next_item_pointer++;
+  }
+  count_ids_--; // decrement the count;
 }
 
 bool GroupSyncWrite::changeParam(uint8_t id, uint8_t *data)
 {
-  if (!ph_)
-    return false;
-  
-  std::vector<uint8_t>::iterator it = std::find(id_list_.begin(), id_list_.end(), id);
-  if (it == id_list_.end())    // NOT exist
-    return false;
-
-  delete[] data_list_[id];
-  data_list_[id]    = new uint8_t[data_length_];
-  for (int c = 0; c < data_length_; c++)
-    data_list_[id][c] = data[c];
-
-  is_param_changed_   = true;
-  return true;
+  // in this version just use addParam
+  return addParam(id, data);
 }
 
 void GroupSyncWrite::clearParam()
 {
-  if (!ph_)
-    return;
-  
-  if (id_list_.size() == 0)
-    return;
+  count_ids_ = 0;
+}  
 
-  for (unsigned int i = 0; i < id_list_.size(); i++)
-    delete[] data_list_[id_list_[i]];
-
-  id_list_.clear();
-  data_list_.clear();
-  if (param_ != 0)
-    delete[] param_;
-  param_ = 0;
-}
 
 int GroupSyncWrite::txPacket()
 {
   if (!ph_)
     return COMM_NOT_AVAILABLE;
   
-  if (id_list_.size() == 0)
+  if (count_ids_ == 0)
     return COMM_NOT_AVAILABLE;
 
-  if (is_param_changed_ == true || param_ == 0)
-    makeParam();
 
-  return ph_->syncWriteTxOnly(port_, start_address_, data_length_, param_, id_list_.size() * (1 + data_length_));
+  return ph_->syncWriteTxOnly(port_, start_address_, data_length_, param_, count_ids_ * (1 + data_length_));
 }

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/src/dynamixel_sdk/group_sync_write.cpp
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/src/dynamixel_sdk/group_sync_write.cpp
@@ -56,6 +56,24 @@ GroupSyncWrite::GroupSyncWrite(PortHandler *port, PacketHandler *ph, uint16_t st
   clearParam();
 }
 
+GroupSyncWrite::GroupSyncWrite(uint16_t start_address, uint16_t data_length)
+  : port_(NULL),
+    ph_(NULL),
+    is_param_changed_(false),
+    param_(0),
+    start_address_(start_address),
+    data_length_(data_length)
+{
+}
+
+void GroupSyncWrite::init(PortHandler *port, PacketHandler *ph)
+{
+  port_ = port;
+  ph_ = ph;
+  Serial.printf("GroupSyncWrite::Init called %x %x\n", (uint32_t)port_, (uint32_t)ph_); Serial.flush();
+  clearParam();
+}
+
 void GroupSyncWrite::makeParam()
 {
   if (id_list_.size() == 0) return;
@@ -81,6 +99,9 @@ void GroupSyncWrite::makeParam()
 
 bool GroupSyncWrite::addParam(uint8_t id, uint8_t *data)
 {
+  if (!ph_)
+    return false;
+
   if (std::find(id_list_.begin(), id_list_.end(), id) != id_list_.end())   // id already exist
     return false;
 
@@ -95,6 +116,9 @@ bool GroupSyncWrite::addParam(uint8_t id, uint8_t *data)
 
 void GroupSyncWrite::removeParam(uint8_t id)
 {
+  if (!ph_)
+    return;
+  
   std::vector<uint8_t>::iterator it = std::find(id_list_.begin(), id_list_.end(), id);
   if (it == id_list_.end())    // NOT exist
     return;
@@ -108,6 +132,9 @@ void GroupSyncWrite::removeParam(uint8_t id)
 
 bool GroupSyncWrite::changeParam(uint8_t id, uint8_t *data)
 {
+  if (!ph_)
+    return false;
+  
   std::vector<uint8_t>::iterator it = std::find(id_list_.begin(), id_list_.end(), id);
   if (it == id_list_.end())    // NOT exist
     return false;
@@ -123,6 +150,9 @@ bool GroupSyncWrite::changeParam(uint8_t id, uint8_t *data)
 
 void GroupSyncWrite::clearParam()
 {
+  if (!ph_)
+    return;
+  
   if (id_list_.size() == 0)
     return;
 
@@ -138,6 +168,9 @@ void GroupSyncWrite::clearParam()
 
 int GroupSyncWrite::txPacket()
 {
+  if (!ph_)
+    return COMM_NOT_AVAILABLE;
+  
   if (id_list_.size() == 0)
     return COMM_NOT_AVAILABLE;
 

--- a/arduino/opencr_arduino/opencr/libraries/OpenCR/examples/07. DynamixelSDK/protocol2.0/extended_sync_read_write/extended_sync_read_write.ino
+++ b/arduino/opencr_arduino/opencr/libraries/OpenCR/examples/07. DynamixelSDK/protocol2.0/extended_sync_read_write/extended_sync_read_write.ino
@@ -103,9 +103,10 @@ const uint8_t servo_list[COUNT_SERVOS] = {DXL1_ID, DXL2_ID};
 
 #ifdef GLOBAL_SYNC_OBJECTS
 dynamixel::GroupSyncWrite gsw(ADDR_X_PROFILE_VELOCITY, LEN_X_PROFILE_VELOCITY + LEN_X_GOAL_POSITION);
-uint8_t gsw_buffer[(LEN_X_PROFILE_VELOCITY + LEN_X_GOAL_POSITION + 1) * COUNT_SERVOS];
+uint8_t gsw_buffer[(LEN_X_PROFILE_VELOCITY + LEN_X_GOAL_POSITION + dynamixel::GroupSyncWrite::EXTRA_BYTES_PER_ITEM) * COUNT_SERVOS];
 
 dynamixel::GroupSyncRead gsr(ADDR_X_PRESENT_LOAD, LEN_X_PRESENT_LOAD + LEN_X_PRESENT_VELOCITY + LEN_X_PRESENT_POSITION);
+uint8_t gsr_buffer[(LEN_X_PRESENT_LOAD + LEN_X_PRESENT_VELOCITY + LEN_X_PRESENT_POSITION + dynamixel::GroupSyncRead::EXTRA_BYTES_PER_ITEM) * COUNT_SERVOS];
 #endif
 
 dynamixel::GroupSyncWrite *groupSyncWrite;
@@ -148,6 +149,7 @@ void setup()
   groupSyncWrite = &gsw;
 
   gsr.init(portHandler, packetHandler);
+  gsr.setBuffer(gsr_buffer, sizeof(gsr_buffer));
   groupSyncRead = &gsr;
 #else
   groupSyncWrite = new dynamixel::GroupSyncWrite(portHandler, packetHandler, ADDR_X_GOAL_POSITION, LEN_X_GOAL_POSITION);
@@ -312,7 +314,7 @@ void quit_test ()
   int dxl_comm_result;
   uint8_t dxl_error;
 
-  Serial.println("/n/n***** Test ending ***");
+  Serial.println("\n\n***** Test ending ***");
 
   // Disable Dynamixel#1 Torque
   // Now loop through and initialize each of the servos.

--- a/arduino/opencr_arduino/opencr/libraries/OpenCR/examples/07. DynamixelSDK/protocol2.0/extended_sync_read_write/extended_sync_read_write.ino
+++ b/arduino/opencr_arduino/opencr/libraries/OpenCR/examples/07. DynamixelSDK/protocol2.0/extended_sync_read_write/extended_sync_read_write.ino
@@ -1,0 +1,359 @@
+/*******************************************************************************
+  Copyright (c) 2016, ROBOTIS CO., LTD.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+* * Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+* * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+* * Neither the name of ROBOTIS nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/* Code started from sync_read_write example by: Ryu Woon Jung (Leon) */
+
+// Updated by KurtE: to use two XL430-W250 running at 1MBS on
+// OpenCM and OPenCR.
+// This version was extended to have the SyncRead read in multiple addresses
+
+// Also this version moves many of the main variables into global variables instead of being
+// local to setup, as to avoid accidents of later creating global version, but not make
+// the statements in Setup just be an assignement and then fault when you use them in loop...
+
+//
+// Available Dynamixel model on this example : All models using Protocol 2.0
+//
+
+#include <DynamixelSDK.h>
+
+// Control table address
+#define ADDR_X_TORQUE_ENABLE        64  // 1 0
+
+#define ADDR_X_PROFILE_VELOCITY     112 // 4
+#define ADDR_X_GOAL_POSITION        116 // 4
+#define ADDR_X_PRESENT_LOAD         126 // 2 (R)
+#define ADDR_X_PRESENT_VELOCITY     128 // 4 (R)
+#define ADDR_X_PRESENT_POSITION     132 // 4 (R)
+
+
+// Data Byte Length
+#define LEN_X_PROFILE_VELOCITY        4
+#define LEN_X_GOAL_POSITION           4
+#define LEN_X_PRESENT_LOAD            2
+#define LEN_X_PRESENT_VELOCITY        4
+#define LEN_X_PRESENT_POSITION        4
+
+// Protocol version
+#define PROTOCOL_VERSION                2.0                 // See which protocol version is used in the Dynamixel
+
+// Default setting
+#define DXL1_ID                         1                   // Dynamixel#1 ID: 1
+#define DXL2_ID                         2                   // Dynamixel#2 ID: 2
+#define BAUDRATE                        1000000
+#if defined(__OPENCR__)
+#define DEVICENAME                      "3"                 // This definition only has a symbolic meaning and does not affect to any functionality
+#elif defined(__OPENCM904__)
+#define DEVICENAME                      "3"                 // Open CM485 expansion board
+//#define DEVICENAME                    "1"                 // Open CM905 built in ports
+#endif
+
+#define TORQUE_ENABLE                   1                   // Value for enabling the torque
+#define TORQUE_DISABLE                  0                   // Value for disabling the torque
+#define DXL_MINIMUM_POSITION_VALUE     1024                 // Dynamixel will rotate between this value
+#define DXL_MAXIMUM_POSITION_VALUE     3072                 // and this value (note that the Dynamixel would not move when the position value is out of movable range. Check e-manual about the range of the Dynamixel you use.)
+#define DXL_VELOCITY_1                  100                 // First moves speed
+#define DXL_VELOCITY_2                  300                 // Second moves speed
+#define DXL_MOVING_STATUS_THRESHOLD     20                  // Dynamixel moving status threshold
+#define DXL_MOVING_VELOCITY_THRESHOLD   3                   // Not sure what is good one here
+
+#define ESC_ASCII_VALUE                 0x1b
+
+
+//----------------------------------------------------------------------
+// Globals
+//----------------------------------------------------------------------
+dynamixel::PortHandler *portHandler;
+dynamixel::PacketHandler *packetHandler;
+
+#define COUNT_SERVOS 2
+
+const uint8_t servo_list[COUNT_SERVOS] = {DXL1_ID, DXL2_ID};
+
+// Question to self and others.  Ok to have global GroupSync objects?  Nope...
+// Initialize GroupSyncWrite instance
+#define GLOBAL_SYNC_OBJECTS
+
+#ifdef GLOBAL_SYNC_OBJECTS
+dynamixel::GroupSyncWrite gsw(ADDR_X_PROFILE_VELOCITY, LEN_X_PROFILE_VELOCITY + LEN_X_GOAL_POSITION);
+uint8_t gsw_buffer[(LEN_X_PROFILE_VELOCITY + LEN_X_GOAL_POSITION + 1) * COUNT_SERVOS];
+
+dynamixel::GroupSyncRead gsr(ADDR_X_PRESENT_LOAD, LEN_X_PRESENT_LOAD + LEN_X_PRESENT_VELOCITY + LEN_X_PRESENT_POSITION);
+#endif
+
+dynamixel::GroupSyncWrite *groupSyncWrite;
+
+// Initialize Groupsyncread instance for Present Position
+dynamixel::GroupSyncRead *groupSyncRead;
+
+const uint32_t dxl_goal_position[2] = {DXL_MINIMUM_POSITION_VALUE, DXL_MAXIMUM_POSITION_VALUE};         // Goal position
+const uint32_t dxl_goal_velocity[2] = {DXL_VELOCITY_1, DXL_VELOCITY_2};
+int goal_position_index = 0;
+
+//----------------------------------------------------------------------
+// Forward references
+//----------------------------------------------------------------------
+extern bool report_any_dxl_errors(int dxl_comm_result, uint8_t dxl_error, uint8_t id);
+
+//----------------------------------------------------------------------
+
+void setup()
+{
+  pinMode(LED_BUILTIN, OUTPUT);   // enable the LED pin
+
+  Serial.begin(115200);
+  while (!Serial);
+
+  int dxl_comm_result = COMM_TX_FAIL;             // Communication result
+  //bool dxl_getdata_result = false;                 // GetParam result
+
+  uint8_t dxl_error = 0;                          // Dynamixel error
+
+  // Initialize PortHandler instance
+  portHandler = dynamixel::PortHandler::getPortHandler(DEVICENAME);
+
+  // Initialize PacketHandler instance
+  packetHandler = dynamixel::PacketHandler::getPacketHandler(PROTOCOL_VERSION);
+
+#ifdef GLOBAL_SYNC_OBJECTS
+  gsw.init(portHandler, packetHandler);
+  gsw.setBuffer(gsw_buffer, sizeof(gsw_buffer));
+  groupSyncWrite = &gsw;
+
+  gsr.init(portHandler, packetHandler);
+  groupSyncRead = &gsr;
+#else
+  groupSyncWrite = new dynamixel::GroupSyncWrite(portHandler, packetHandler, ADDR_X_GOAL_POSITION, LEN_X_GOAL_POSITION);
+
+  // Initialize Groupsyncread instance for Present Position
+  groupSyncRead = new dynamixel::GroupSyncRead(portHandler, packetHandler, ADDR_X_PRESENT_LOAD, LEN_X_PRESENT_LOAD + LEN_X_PRESENT_VELOCITY + LEN_X_PRESENT_POSITION);
+#endif
+
+  // Open port
+  if (portHandler->openPort())
+  {
+    Serial.print("Succeeded to open the port!\n");
+  }
+  else
+  {
+    Serial.print("Failed to open the port!\n");
+    return;
+  }
+
+  // Set port baudrate
+  if (portHandler->setBaudRate(BAUDRATE))
+  {
+    Serial.print("Succeeded to change the baudrate!\n");
+  }
+  else
+  {
+    Serial.print("Failed to change the baudrate!\n");
+    return;
+  }
+  Serial.println("Before Torque Enable"); Serial.flush();
+
+  // Now loop through and initialize each of the servos.
+  for (uint8_t servo_index = 0; servo_index < COUNT_SERVOS; servo_index++)
+  {
+    // enable torque on the servo
+    dxl_comm_result = packetHandler->write1ByteTxRx(portHandler, servo_list[servo_index], ADDR_X_TORQUE_ENABLE, TORQUE_ENABLE, &dxl_error);
+    if (!report_any_dxl_errors(dxl_comm_result, dxl_error, servo_list[servo_index]))
+    {
+      Serial.print("[ID:"); Serial.print(servo_list[servo_index]); Serial.println("] Torque enabled");
+    }
+
+    // Add the servo to the group read list
+    if (!groupSyncRead->addParam(servo_list[servo_index]))
+    {
+      Serial.printf("groupSyncRead addparam failed Dynamixel id[%d]\n", servo_list[servo_index]);
+    }
+  }
+}
+
+void loop()
+{
+  int32_t dxl_present_position[COUNT_SERVOS];      // Present position
+  int32_t dxl_present_velocity[COUNT_SERVOS];      // Present velocity
+  int32_t dxl_present_load[COUNT_SERVOS];          // Present load
+  int dxl_comm_result = COMM_TX_FAIL;              // Communication result
+  bool still_moving;
+
+  Serial.println("Press any key to continue! (or press q to quit!)\n");
+
+  while ( Serial.available() == 0 )  ;
+
+  uint8_t ch = Serial.read(); // get the first char
+  if (ch == 'q')
+  {
+    quit_test();
+  }
+  while (Serial.available())
+  {
+    Serial.read();  // clear out any other chars
+  }
+
+  // Now loop through and initialize each of the servos.
+  for (uint8_t servo_index = 0; servo_index < COUNT_SERVOS; servo_index++)
+  {
+    // Add Dynamixels goal position value to the Syncwrite storage
+    if (!groupSyncWrite->setParam(servo_list[servo_index], ADDR_X_GOAL_POSITION, LEN_X_GOAL_POSITION,
+                                  dxl_goal_position[goal_position_index]))
+    {
+      Serial.printf("groupSyncWrite setParam goal position failed Dynamixel id[%d]\n", servo_list[servo_index]);
+    }
+
+    // Add Dynamixels profile velocity
+    if (!groupSyncWrite->setParam(servo_list[servo_index], ADDR_X_PROFILE_VELOCITY, LEN_X_PROFILE_VELOCITY,
+                                  dxl_goal_velocity[goal_position_index]))
+    {
+      Serial.printf("groupSyncWrite setParam velocity failed Dynamixel id[%d]\n", servo_list[servo_index]);
+    }
+  }
+
+  // Syncwrite goal position
+  dxl_comm_result = groupSyncWrite->txPacket();
+  report_any_dxl_errors(dxl_comm_result, 0, 0xfe);
+
+  // Clear syncwrite parameter storage - now simply sets count to zero
+  groupSyncWrite->clearParam();
+
+  do
+  {
+    digitalWrite(LED_BUILTIN, !digitalRead(LED_BUILTIN)); // play with LED pin
+    // Syncread present position
+    dxl_comm_result = groupSyncRead->txRxPacket();
+    report_any_dxl_errors(dxl_comm_result, 0, 0xfe);
+
+    still_moving = false; // See if any of the servos still show as moving.
+
+    for (uint8_t servo_index = 0; servo_index < COUNT_SERVOS; servo_index++)
+    {
+      // Check for any character input, if so break out...
+      if (Serial.available())
+      {
+        while (Serial.available())
+        {
+          Serial.read();  // remove all before continue
+        }
+        break;
+      }
+      // Check if groupsyncread data of Dynamixel#1 is available
+      if (groupSyncRead->isAvailable(servo_list[servo_index], ADDR_X_PRESENT_POSITION, LEN_X_PRESENT_POSITION))
+      {
+        // Get Dynamixel#1 present values
+        dxl_present_position[servo_index] = groupSyncRead->getData(servo_list[servo_index], ADDR_X_PRESENT_POSITION, LEN_X_PRESENT_POSITION);
+        dxl_present_velocity[servo_index] = groupSyncRead->getData(servo_list[servo_index], ADDR_X_PRESENT_VELOCITY, LEN_X_PRESENT_VELOCITY);
+        dxl_present_load[servo_index] =     groupSyncRead->getData(servo_list[servo_index], ADDR_X_PRESENT_LOAD, LEN_X_PRESENT_LOAD);
+
+        Serial.print("[ID:"); Serial.print(servo_list[servo_index]);
+        Serial.print("] Goal:"); Serial.print(dxl_goal_position[goal_position_index]);
+        Serial.print(" "); Serial.print(dxl_goal_velocity[goal_position_index]);
+        Serial.print(" Pres(p/v/l):"); Serial.print(dxl_present_position[servo_index]);
+        Serial.print(" "); Serial.print(dxl_present_velocity[servo_index]);
+        Serial.print(" "); Serial.print(dxl_present_load[servo_index]);
+
+        if ((abs((int)dxl_goal_position[goal_position_index] - dxl_present_position[servo_index]) > DXL_MOVING_STATUS_THRESHOLD) 
+          || (abs(dxl_present_velocity[servo_index]) > DXL_MOVING_VELOCITY_THRESHOLD)) 
+        {
+          still_moving = true;
+        }
+      }
+      else
+      {
+        Serial.print("[ID:"); Serial.print(servo_list[servo_index]); Serial.print("] groupSyncRead getdata failed");
+      }
+    }
+    Serial.println(); // end the current line
+
+  } while (still_moving) ;
+
+  // Change goal position
+  if (goal_position_index == 0)
+  {
+    goal_position_index = 1;
+  }
+  else
+  {
+    goal_position_index = 0;
+  }
+}
+
+
+
+void quit_test ()
+{
+  int dxl_comm_result;
+  uint8_t dxl_error;
+
+  Serial.println("/n/n***** Test ending ***");
+
+  // Disable Dynamixel#1 Torque
+  // Now loop through and initialize each of the servos.
+  for (uint8_t servo_index = 0; servo_index < COUNT_SERVOS; servo_index++)
+  {
+    dxl_comm_result = packetHandler->write1ByteTxRx(portHandler, servo_list[servo_index], ADDR_X_TORQUE_ENABLE, TORQUE_DISABLE, &dxl_error);
+    report_any_dxl_errors(dxl_comm_result, dxl_error, servo_list[servo_index]);
+  }
+
+  // Close port
+  portHandler->closePort();
+
+  Serial.println("Test completed, must reset board to do anything...");
+  while (1)
+  {
+    digitalWrite(LED_BUILTIN, !digitalRead(LED_BUILTIN)); // play with LED pin
+    delay(500);
+  }
+}
+
+
+bool report_any_dxl_errors(int dxl_comm_result, uint8_t dxl_error, uint8_t id)
+{
+  if (dxl_comm_result != COMM_SUCCESS)
+  {
+    if (id != 0xfe)
+    {
+      Serial.print("ID["); Serial.print(id, DEC); Serial.print("] ");
+    }
+    Serial.print(packetHandler->getTxRxResult(dxl_comm_result));
+    return true;
+  }
+  else if (dxl_error != 0)
+  {
+    if (id != 0xfe)
+    {
+      Serial.print("ID["); Serial.print(id, DEC); Serial.print("] ");
+    }
+    Serial.print(packetHandler->getRxPacketError(dxl_error));
+    return true;
+  }
+
+  return false; // did not report anything
+}

--- a/arduino/opencr_arduino/opencr/libraries/OpenCR/examples/08. DynamixelWorkbench/t_Find_Dynamixel/t_Find_Dynamixel.ino
+++ b/arduino/opencr_arduino/opencr/libraries/OpenCR/examples/08. DynamixelWorkbench/t_Find_Dynamixel/t_Find_Dynamixel.ino
@@ -1,38 +1,45 @@
 /*******************************************************************************
-* Copyright 2016 ROBOTIS CO., LTD.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
+  Copyright 2016 ROBOTIS CO., LTD.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 *******************************************************************************/
 
 /* Authors: Taehun Lim (Darby) */
+/* Updates by Kurt */
 
 #include <DynamixelWorkbench.h>
 
 #if defined(__OPENCM904__)
-  #define DEVICE_NAME "3" //Dynamixel on Serial3(USART3)  <-OpenCM 485EXP
+#define DEVICE_NAME "3" //Dynamixel on Serial3(USART3)  <-OpenCM 485EXP
 #elif defined(__OPENCR__)
-  #define DEVICE_NAME ""
-#endif   
+#define DEVICE_NAME ""
+#endif
 
 #define BAUDRATE_NUM 3
 
 DynamixelWorkbench dxl_wb;
 
-void setup() 
+void setup()
 {
   Serial.begin(57600);
-  while(!Serial); // Open a Serial Monitor 
+  while (!Serial); // Open a Serial Monitor
+  Serial.println("Find Dynamixel Servos test");
+  Serial.print("Size of DynamixelWorkbench: "); Serial.println(sizeof(DynamixelWorkbench), DEC);
 
+}
+
+void loop()
+{
   uint8_t scanned_id[16] = {0, };
   uint8_t dxl_cnt = 0;
   uint32_t baud[BAUDRATE_NUM] = {9600, 57600, 1000000};
@@ -48,15 +55,18 @@ void setup()
 
     for (int i = 0; i < dxl_cnt; i++)
     {
-      Serial.println("   id : " + String(scanned_id[i]) + "   Model Name : " + String(dxl_wb.getModelName(scanned_id[i])));
+      Serial.print("   id : ");
+      Serial.print(scanned_id[i], DEC);
+      Serial.print("   Model Name : ");
+      Serial.println(dxl_wb.getModelName(scanned_id[i]));
     }
 
-    index++;    
+    index++;
   }
-  Serial.println("End");
-}
-
-void loop() 
-{
-
+  Serial.println("End - Press any key to restart test");
+  while (Serial.available() == 0) ;
+  while (Serial.available())
+  {
+    Serial.read();
+  }
 }


### PR DESCRIPTION
Put up this Pull Request, that tries to reduce or eliminate any memory allocations done as part of group_sync_read or group_sync_write.   

They both create a single buffer, that holds all of the data.  It also allows the using program to statically define this buffer and tell the code to use their buffer instead.   This allows programs to get a better understanding of exactly how much memory they are using. 

Also it removes all of the calls to heap manager.  (Except to allocate and free the one buffer)

I also added a method to sync write that worked like Sync Read, such that you could pass in an uint32 value and size of your field and it would do the appropriate packing.

So far I have only done these two objects.  Something similar could be done for the Bulk read and write.

If this level of change looks valid to you, I can also migrate this code over to both the SDK project as well as OpenCM.

This pull also includes an extended Sync Read and write example that the Sync Write updates both position and velocity and reads in position, velocity and force assuming XL430... servos.

I may have also semi accidentally checked in my Dynamixel workbench test (find servos) update that made it more Arduino ish, like using Serial.print(...) function instead of concatenating strings.  Also moved code to loop, to allow it to run again.  And maybe a debug message I had which printed out the size of the workbench object. 

Let me know if you like these changes or if you think parts of it should change. 

