### PR TITLE
Minor protocol 2 memory reductions.

### DIFF
--- a/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/src/dynamixel_sdk/protocol1_packet_handler.cpp
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelSDK/src/dynamixel_sdk/protocol1_packet_handler.cpp
@@ -532,6 +532,7 @@ int Protocol1PacketHandler::writeTxOnly(PortHandler *port, uint8_t id, uint16_t 
   int result                 = COMM_TX_FAIL;
 
   uint8_t *txpacket           = (uint8_t *)malloc(length+7);
+  if (!txpacket) return result;
   //uint8_t *txpacket           = new uint8_t[length+7];
 
   txpacket[PKT_ID]            = id;
@@ -613,6 +614,7 @@ int Protocol1PacketHandler::regWriteTxOnly(PortHandler *port, uint8_t id, uint16
   int result                 = COMM_TX_FAIL;
 
   uint8_t *txpacket           = (uint8_t *)malloc(length+6);
+  if (!txpacket) return result;
   //uint8_t *txpacket           = new uint8_t[length+6];
 
   txpacket[PKT_ID]            = id;
@@ -666,6 +668,7 @@ int Protocol1PacketHandler::syncWriteTxOnly(PortHandler *port, uint16_t start_ad
   int result                 = COMM_TX_FAIL;
 
   uint8_t *txpacket           = (uint8_t *)malloc(param_length+8);
+  if (!txpacket) return result;
   // 8: HEADER0 HEADER1 ID LEN INST START_ADDR DATA_LEN ... CHKSUM
   //uint8_t *txpacket           = new uint8_t[param_length + 8];
 


### PR DESCRIPTION
Made CRC table be static const
Checked for malloc fail on txbuffers
Changed Addstuffing, to not need large buffer on stack
Restore from before max read/write on OpenCM boards is 2K not 4K. 

As I mentioned in the Dynamixel SDK issue: https://github.com/ROBOTIS-GIT/DynamixelSDK/issues/258

This is a small subset of the stuff I am trying out on the OpenCM project. 

Could add additional stuff if interested, like setup RX buffers to be expected size not max message... 