### PR TITLE
Change OpenCR device and permissions to group `dialout`

### DIFF
--- a/99-opencr-cdc.rules
+++ b/99-opencr-cdc.rules
@@ -4,7 +4,8 @@
 #sudo udevadm control --reload-rules
 #sudo udevadm trigger
 
-ATTRS{idVendor}=="0483" ATTRS{idProduct}=="5740", ENV{ID_MM_DEVICE_IGNORE}="1", MODE:="0666"
-ATTRS{idVendor}=="0483" ATTRS{idProduct}=="df11", MODE:="0666"
-ATTRS{idVendor}=="fff1" ATTRS{idProduct}=="ff48", ENV{ID_MM_DEVICE_IGNORE}="1", MODE:="0666"
-ATTRS{idVendor}=="10c4" ATTRS{idProduct}=="ea60", ENV{ID_MM_DEVICE_IGNORE}="1", MODE:="0666"
+ATTRS{idVendor}=="0483" ATTRS{idProduct}=="5740", ENV{ID_MM_DEVICE_IGNORE}="1", OWNER="root", GROUP="dialout", MODE:="0660"
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0483" ATTRS{idProduct}=="5740", SYMLINK+="opencr%n"
+ATTRS{idVendor}=="0483" ATTRS{idProduct}=="df11", OWNER="root", GROUP="dialout", MODE:="0660"
+ATTRS{idVendor}=="fff1" ATTRS{idProduct}=="ff48", ENV{ID_MM_DEVICE_IGNORE}="1", OWNER="root", GROUP="dialout", MODE:="0660"
+ATTRS{idVendor}=="10c4" ATTRS{idProduct}=="ea60", ENV{ID_MM_DEVICE_IGNORE}="1", OWNER="root", GROUP="dialout", MODE:="0660"


### PR DESCRIPTION
Given modern security issues, it seems like making /dev/ttyACM0 world writable might not be the best choice, perhaps assigning it to group `dialout` would be better.

In addition to the updated udev rule, this does require that the user is added to the group
```console
$ sudo usermod -a -G dialout $USER
```
Unfortunately this does not update the current shell so the user needs to log out and back in or run the following command.
```console
exec sg dialout newgrp `id -gn`
```
Given that many robots have several serial ports, symlinking /dev/ttyACM0 to /dev/opencr0 for matching USB VID/PID seems helpful.

We are happy to help update the documentation if this can be merged.