### PR TITLE
Fix typo: avaliable -> available

### DIFF
--- a/arduino/opencr_arduino/opencr/libraries/CAN/CAN.cpp
+++ b/arduino/opencr_arduino/opencr/libraries/CAN/CAN.cpp
@@ -55,7 +55,7 @@ uint8_t CANClass::read(void)  //read one byte
     return drvCanRead(OPENCR_CAN_CHANNEL);
 }
 
-uint32_t  CANClass::avaliable(void)
+uint32_t  CANClass::available(void)
 {
     return drvCanAvailable(OPENCR_CAN_CHANNEL); 
 }
@@ -92,7 +92,7 @@ bool CANClass::readMessage(can_message_t *p_msg)
     return ret;
 }
 
-uint32_t CANClass::avaliableMessage(void)
+uint32_t CANClass::availableMessage(void)
 {
      return drvCanAvailableMsg(OPENCR_CAN_CHANNEL);
 }

--- a/arduino/opencr_arduino/opencr/libraries/CAN/CAN.h
+++ b/arduino/opencr_arduino/opencr/libraries/CAN/CAN.h
@@ -35,10 +35,10 @@ public:
     uint32_t write(uint32_t id, uint8_t *p_data, uint32_t length);  //write data
     uint32_t write(uint32_t id, uint8_t *p_data, uint32_t length, uint8_t format);
     uint8_t read(void); //read one byte
-    uint32_t  avaliable(void);
+    uint32_t  available(void);
     uint32_t writeMessage(can_message_t *p_msg);
     bool readMessage(can_message_t *p_msg);
-    uint32_t avaliableMessage(void);
+    uint32_t availableMessage(void);
 
     uint8_t getErrCount(void);
     uint32_t getError(void);

--- a/arduino/opencr_arduino/opencr/libraries/Eigen331/src/Eigen/src/OrderingMethods/Eigen_Colamd.h
+++ b/arduino/opencr_arduino/opencr/libraries/Eigen331/src/Eigen/src/OrderingMethods/Eigen_Colamd.h
@@ -1688,7 +1688,7 @@ static void detect_super_cols
 
 /*
   Defragments and compacts columns and rows in the workspace A.  Used when
-  all avaliable memory has been used while performing row merging.  Returns
+  all available memory has been used while performing row merging.  Returns
   the index of the first free position in A, after garbage collection.  The
   time taken by this routine is linear is the size of the array A, which is
   itself linear in the number of nonzeros in the input matrix.

--- a/arduino/opencr_arduino/opencr/libraries/OpenCR/examples/10. Etc/CAN/canTxRxByte/canTxRxByte.ino
+++ b/arduino/opencr_arduino/opencr/libraries/OpenCR/examples/10. Etc/CAN/canTxRxByte/canTxRxByte.ino
@@ -74,7 +74,7 @@ void setup()
 
 void loop() 
 {
-  if(CanBus.avaliableMessage())
+  if(CanBus.availableMessage())
   {
     Serial.print((char)CanBus.read());
   }

--- a/arduino/opencr_arduino/opencr/libraries/OpenCR/examples/10. Etc/CAN/canTxRxMessage/canTxRxMessage.ino
+++ b/arduino/opencr_arduino/opencr/libraries/OpenCR/examples/10. Etc/CAN/canTxRxMessage/canTxRxMessage.ino
@@ -77,7 +77,7 @@ void setup()
 
 void loop()
 {
-  if (CanBus.avaliableMessage())
+  if (CanBus.availableMessage())
   {
     if(CanBus.readMessage(&rx_msg))
     {


### PR DESCRIPTION
Fixes a typo in the CAN library, the examples depending on that library and comment in Eigen_Colamd.h.