### PR TITLE
Update BatteryState message for Noetic

### DIFF
--- a/arduino/opencr_arduino/opencr/libraries/turtlebot3/src/turtlebot3/turtlebot3_sensor.cpp
+++ b/arduino/opencr_arduino/opencr/libraries/turtlebot3/src/turtlebot3/turtlebot3_sensor.cpp
@@ -38,6 +38,7 @@ bool Turtlebot3Sensor::init(void)
 
   uint8_t get_error_code = 0x00;
 
+  battery_state_msg_.temperature     = NAN;
   battery_state_msg_.current         = NAN;
   battery_state_msg_.charge          = NAN;
   battery_state_msg_.capacity        = NAN;

--- a/arduino/opencr_arduino/opencr/libraries/turtlebot3_ros_lib/sensor_msgs/BatteryState.h
+++ b/arduino/opencr_arduino/opencr/libraries/turtlebot3_ros_lib/sensor_msgs/BatteryState.h
@@ -17,6 +17,8 @@ namespace sensor_msgs
       _header_type header;
       typedef float _voltage_type;
       _voltage_type voltage;
+      typedef float _temperature_type;
+      _temperature_type temperature;
       typedef float _current_type;
       _current_type current;
       typedef float _charge_type;
@@ -39,6 +41,10 @@ namespace sensor_msgs
       typedef float _cell_voltage_type;
       _cell_voltage_type st_cell_voltage;
       _cell_voltage_type * cell_voltage;
+      uint32_t cell_temperature_length;
+      typedef float _cell_temperature_type;
+      _cell_temperature_type st_cell_temperature;
+      _cell_temperature_type * cell_temperature;
       typedef const char* _location_type;
       _location_type location;
       typedef const char* _serial_number_type;
@@ -68,6 +74,7 @@ namespace sensor_msgs
     BatteryState():
       header(),
       voltage(0),
+      temperature(0),
       current(0),
       charge(0),
       capacity(0),
@@ -78,6 +85,7 @@ namespace sensor_msgs
       power_supply_technology(0),
       present(0),
       cell_voltage_length(0), cell_voltage(NULL),
+      cell_temperature_length(0), cell_temperature(NULL),
       location(""),
       serial_number("")
     {
@@ -97,6 +105,16 @@ namespace sensor_msgs
       *(outbuffer + offset + 2) = (u_voltage.base >> (8 * 2)) & 0xFF;
       *(outbuffer + offset + 3) = (u_voltage.base >> (8 * 3)) & 0xFF;
       offset += sizeof(this->voltage);
+      union {
+        float real;
+        uint32_t base;
+      } u_temperature;
+      u_temperature.real = this->temperature;
+      *(outbuffer + offset + 0) = (u_temperature.base >> (8 * 0)) & 0xFF;
+      *(outbuffer + offset + 1) = (u_temperature.base >> (8 * 1)) & 0xFF;
+      *(outbuffer + offset + 2) = (u_temperature.base >> (8 * 2)) & 0xFF;
+      *(outbuffer + offset + 3) = (u_temperature.base >> (8 * 3)) & 0xFF;
+      offset += sizeof(this->temperature);
       union {
         float real;
         uint32_t base;
@@ -177,6 +195,23 @@ namespace sensor_msgs
       *(outbuffer + offset + 3) = (u_cell_voltagei.base >> (8 * 3)) & 0xFF;
       offset += sizeof(this->cell_voltage[i]);
       }
+      *(outbuffer + offset + 0) = (this->cell_temperature_length >> (8 * 0)) & 0xFF;
+      *(outbuffer + offset + 1) = (this->cell_temperature_length >> (8 * 1)) & 0xFF;
+      *(outbuffer + offset + 2) = (this->cell_temperature_length >> (8 * 2)) & 0xFF;
+      *(outbuffer + offset + 3) = (this->cell_temperature_length >> (8 * 3)) & 0xFF;
+      offset += sizeof(this->cell_temperature_length);
+      for( uint32_t i = 0; i < cell_temperature_length; i++){
+      union {
+        float real;
+        uint32_t base;
+      } u_cell_temperaturei;
+      u_cell_temperaturei.real = this->cell_temperature[i];
+      *(outbuffer + offset + 0) = (u_cell_temperaturei.base >> (8 * 0)) & 0xFF;
+      *(outbuffer + offset + 1) = (u_cell_temperaturei.base >> (8 * 1)) & 0xFF;
+      *(outbuffer + offset + 2) = (u_cell_temperaturei.base >> (8 * 2)) & 0xFF;
+      *(outbuffer + offset + 3) = (u_cell_temperaturei.base >> (8 * 3)) & 0xFF;
+      offset += sizeof(this->cell_temperature[i]);
+      }
       uint32_t length_location = strlen(this->location);
       varToArr(outbuffer + offset, length_location);
       offset += 4;
@@ -205,6 +240,17 @@ namespace sensor_msgs
       u_voltage.base |= ((uint32_t) (*(inbuffer + offset + 3))) << (8 * 3);
       this->voltage = u_voltage.real;
       offset += sizeof(this->voltage);
+      union {
+        float real;
+        uint32_t base;
+      } u_temperature;
+      u_temperature.base = 0;
+      u_temperature.base |= ((uint32_t) (*(inbuffer + offset + 0))) << (8 * 0);
+      u_temperature.base |= ((uint32_t) (*(inbuffer + offset + 1))) << (8 * 1);
+      u_temperature.base |= ((uint32_t) (*(inbuffer + offset + 2))) << (8 * 2);
+      u_temperature.base |= ((uint32_t) (*(inbuffer + offset + 3))) << (8 * 3);
+      this->temperature = u_temperature.real;
+      offset += sizeof(this->temperature);
       union {
         float real;
         uint32_t base;
@@ -296,6 +342,28 @@ namespace sensor_msgs
       offset += sizeof(this->st_cell_voltage);
         memcpy( &(this->cell_voltage[i]), &(this->st_cell_voltage), sizeof(float));
       }
+      uint32_t cell_temperature_lengthT = ((uint32_t) (*(inbuffer + offset)));
+      cell_temperature_lengthT |= ((uint32_t) (*(inbuffer + offset + 1))) << (8 * 1);
+      cell_temperature_lengthT |= ((uint32_t) (*(inbuffer + offset + 2))) << (8 * 2);
+      cell_temperature_lengthT |= ((uint32_t) (*(inbuffer + offset + 3))) << (8 * 3);
+      offset += sizeof(this->cell_temperature_length);
+      if(cell_temperature_lengthT > cell_temperature_length)
+        this->cell_temperature = (float*)realloc(this->cell_temperature, cell_temperature_lengthT * sizeof(float));
+      cell_temperature_length = cell_temperature_lengthT;
+      for( uint32_t i = 0; i < cell_temperature_length; i++){
+      union {
+        float real;
+        uint32_t base;
+      } u_st_cell_temperature;
+      u_st_cell_temperature.base = 0;
+      u_st_cell_temperature.base |= ((uint32_t) (*(inbuffer + offset + 0))) << (8 * 0);
+      u_st_cell_temperature.base |= ((uint32_t) (*(inbuffer + offset + 1))) << (8 * 1);
+      u_st_cell_temperature.base |= ((uint32_t) (*(inbuffer + offset + 2))) << (8 * 2);
+      u_st_cell_temperature.base |= ((uint32_t) (*(inbuffer + offset + 3))) << (8 * 3);
+      this->st_cell_temperature = u_st_cell_temperature.real;
+      offset += sizeof(this->st_cell_temperature);
+        memcpy( &(this->cell_temperature[i]), &(this->st_cell_temperature), sizeof(float));
+      }
       uint32_t length_location;
       arrToVar(length_location, (inbuffer + offset));
       offset += 4;
@@ -318,7 +386,7 @@ namespace sensor_msgs
     }
 
     const char * getType(){ return "sensor_msgs/BatteryState"; };
-    const char * getMD5(){ return "476f837fa6771f6e16e3bf4ef96f8770"; };
+    const char * getMD5(){ return "4ddae7f048e32fda22cac764685e3974"; };
 
   };
 


### PR DESCRIPTION
This change adds temperature and cell temperature fields to the BatteryState
message and updates the MD5 checksum on the message type. These fields
were added in Noetic in the following commit:
https://github.com/ros/common_msgs/commit/4804aa31c4df20c2143c7a09627a09039dafc1e0

Closes issue #240