### PR TITLE
Fixed imu_selector selecting wrong IMU for magnetometer.

### DIFF
--- a/arduino/opencr_arduino/opencr/libraries/IMU/imu_selector.cpp
+++ b/arduino/opencr_arduino/opencr/libraries/IMU/imu_selector.cpp
@@ -207,8 +207,8 @@ void cIMUDevice::mag_get_adc( void )
   {
     case MPU9250:
       DEV1.mag_get_adc();
-      memcpy(magRAW,DEV2.magRAW,3*sizeof(int16_t));
-      memcpy(magADC,DEV2.magADC,3*sizeof(int16_t));
+      memcpy(magRAW,DEV1.magRAW,3*sizeof(int16_t));
+      memcpy(magADC,DEV1.magADC,3*sizeof(int16_t));
       break;
     case ICM20468:
       DEV2.mag_get_adc();


### PR DESCRIPTION
The magnetometer would always give a value of 0 since for the MPU9250 the ICM20468 function was called, the ICM20468 always returns 0 since it doesnt have a magnetometer.