### PR TITLE
support aarch64 in update.sh

### DIFF
--- a/arduino/opencr_develop/opencr_ld_shell/opencr_update/update.sh
+++ b/arduino/opencr_develop/opencr_ld_shell/opencr_update/update.sh
@@ -3,11 +3,12 @@
 
 architecture=""
 case $(uname -m) in
-    i386)   architecture="386" ;;
-    i686)   architecture="386" ;;
-    x86_64) architecture="amd64" ;;
-    armv7l) architecture="arm" ;;
-    arm)    dpkg --print-architecture | grep -q "arm64" && architecture="arm64" || architecture="arm" ;;
+    i386)    architecture="386" ;;
+    i686)    architecture="386" ;;
+    x86_64)  architecture="amd64" ;;
+    armv7l)  architecture="arm" ;;
+    aarch64) architecture="arm" ;;
+    arm)     dpkg --print-architecture | grep -q "arm64" && architecture="arm64" || architecture="arm" ;;
 esac
 
 echo $(uname -m)


### PR DESCRIPTION
This patch allows 64-bit ARM machines to upload the OpenCR firmware.

Note that this is already applied in the [firmware for ROS2](https://github.com/ROBOTIS-GIT/OpenCR-Binaries/raw/master/turtlebot3/ROS2/latest/opencr_update.tar.bz2).