### PR TITLE
coloring common IMU functions and change default max bulk param in dynamixel workbench to 21

### DIFF
--- a/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/include/dynamixel_workbench_toolbox/dynamixel_driver.h
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/include/dynamixel_workbench_toolbox/dynamixel_driver.h
@@ -31,7 +31,7 @@
 
 #define MAX_DXL_SERIES_NUM  5
 #define MAX_HANDLER_NUM     5
-#define MAX_BULK_PARAMETER  20
+#define MAX_BULK_PARAMETER  21
 
 typedef struct 
 {

--- a/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
+++ b/arduino/opencr_arduino/opencr/libraries/DynamixelWorkbench/src/dynamixel_workbench_toolbox/dynamixel_driver.cpp
@@ -1362,7 +1362,7 @@ bool DynamixelDriver::addBulkReadParam(uint8_t id, uint16_t address, uint16_t le
   }
   else
   {
-    if (log != NULL) *log = "[DynamixelDriver] Too many bulk parameter are added (default buffer size is 10)";
+    if (log != NULL) *log = "[DynamixelDriver] Too many bulk parameter are added (default buffer size is 21)";
     return false;
   }
 
@@ -1400,7 +1400,7 @@ bool DynamixelDriver::addBulkReadParam(uint8_t id, const char *item_name, const 
   }
   else
   {
-    if (log != NULL) *log = "[DynamixelDriver] Too many bulk parameter are added (default buffer size is 10)";
+    if (log != NULL) *log = "[DynamixelDriver] Too many bulk parameter are added (default buffer size is 21)";
     return false;
   }
 

--- a/arduino/opencr_arduino/opencr/libraries/IMU/keywords.txt
+++ b/arduino/opencr_arduino/opencr/libraries/IMU/keywords.txt
@@ -13,10 +13,6 @@ cMPU9250 KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-computeIMU KEYWORD2
-selectBank KEYWORD2
-spiRead KEYWORD2
-spiReadByte KEYWORD2
 gyro_init KEYWORD2
 gyro_get_adc KEYWORD2
 gyro_cali_start KEYWORD2
@@ -29,10 +25,6 @@ acc_common KEYWORD2
 acc_cali_get_done KEYWORD2
 mag_init KEYWORD2
 mag_get_adc KEYWORD2
+mag_cali_start KEYWORD2
 mag_common KEYWORD2
 mag_cali_get_done KEYWORD2
-invSqrt KEYWORD2
-computeAngles KEYWORD2
-imu_spi_write KEYWORD2
-imu_spi_read KEYWORD2
-imu_spi_ak8963_write KEYWORD2

--- a/arduino/opencr_arduino/opencr/libraries/IMU/keywords.txt
+++ b/arduino/opencr_arduino/opencr/libraries/IMU/keywords.txt
@@ -1,0 +1,38 @@
+#######################################
+# Syntax Coloring Map For IMU
+#######################################
+
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+cIMU	KEYWORD1
+cICM20648 KEYWORD1
+cIMUDevice KEYWORD1
+Madgwick KEYWORD1
+cMPU9250 KEYWORD1
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+computeIMU KEYWORD2
+selectBank KEYWORD2
+spiRead KEYWORD2
+spiReadByte KEYWORD2
+gyro_init KEYWORD2
+gyro_get_adc KEYWORD2
+gyro_cali_start KEYWORD2
+gyro_common KEYWORD2
+gyro_cali_get_done KEYWORD2
+acc_init KEYWORD2
+acc_get_adc KEYWORD2
+acc_cali_start KEYWORD2
+acc_common KEYWORD2
+acc_cali_get_done KEYWORD2
+mag_init KEYWORD2
+mag_get_adc KEYWORD2
+mag_common KEYWORD2
+mag_cali_get_done KEYWORD2
+invSqrt KEYWORD2
+computeAngles KEYWORD2
+imu_spi_write KEYWORD2
+imu_spi_read KEYWORD2
+imu_spi_ak8963_write KEYWORD2


### PR DESCRIPTION
recently I worked with build-in IMU on the openCR board,
coloring some common functions will be very helpful during the debugging process