### PR TITLE
Fix precompiled libraries linkage on Arduino

### DIFF
--- a/arduino/opencr_arduino/opencr/platform.txt
+++ b/arduino/opencr_arduino/opencr/platform.txt
@@ -81,7 +81,7 @@ recipe.s.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.S.flags} -mcpu={b
 
 ## Create archives
 recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{archive_file_path}" "{object_file}"
-recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} -mcpu={build.mcu} "-T{build.variant.path}/{build.ldscript}" "-Wl,-Map,{build.path}/{build.project_name}.map" {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" "-L{build.path}" -lm -lgcc -mthumb -Wl,--cref -Wl,--check-sections -Wl,--gc-sections -Wl,--unresolved-symbols=report-all -Wl,--warn-common -Wl,--warn-unresolved-symbols -Wl,--start-group {object_files} -Wl,--whole-archive {compiler.libraries.ldflags} "{build.path}/{archive_file}" -Wl,--no-whole-archive -Wl,--end-group
+recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} -mcpu={build.mcu} "-T{build.variant.path}/{build.ldscript}" "-Wl,-Map,{build.path}/{build.project_name}.map" {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" "-L{build.path}" -lm -lgcc -mthumb -Wl,--cref -Wl,--check-sections -Wl,--gc-sections -Wl,--unresolved-symbols=report-all -Wl,--warn-common -Wl,--warn-unresolved-symbols -Wl,--start-group {object_files} -Wl,--whole-archive "{build.path}/{archive_file}" -Wl,--no-whole-archive {compiler.libraries.ldflags} -Wl,--end-group
 
 ## Create eeprom
 recipe.objcopy.eep.pattern=


### PR DESCRIPTION
This PR fixes precompiled libraries linkage in OpenCR Arduino platform.

**Purpose:**
We are having problems with [micro-ROS for arduino](https://github.com/micro-ROS/micro_ros_arduino) library link process

Our latest implementation includes packages with repeated symbols name and as our library is within the `--whole-archive` linker option, we end up with a lot of multiple definition link errors.

This PR moves our library out to the `--no-whole-archive` part, letting the linker optimize this symbols out.

Related: https://github.com/ROBOTIS-GIT/OpenCR/pull/253 (CC: @pablogs9)
