### PR TITLE
Changed constrained velocity to match motor max better

### DIFF
--- a/arduino/opencr_arduino/opencr/libraries/turtlebot3_ros2/include/turtlebot3/turtlebot3_motor_driver.h
+++ b/arduino/opencr_arduino/opencr/libraries/turtlebot3_ros2/include/turtlebot3/turtlebot3_motor_driver.h
@@ -52,6 +52,7 @@ class Turtlebot3MotorDriver
   bool read_present_velocity(int32_t &left_value, int32_t &right_value);
   bool read_present_current(int16_t &left_value, int16_t &right_value);
   bool read_profile_acceleration(uint32_t &left_value, uint32_t &right_value);
+  bool read_max_velocity(int16_t &left_value, int16_t &right_value);
   
   bool write_velocity(int32_t left_value, int32_t right_value);
   bool write_profile_acceleration(uint32_t left_value, uint32_t right_value);
@@ -64,6 +65,8 @@ class Turtlebot3MotorDriver
   uint8_t left_wheel_id_;
   uint8_t right_wheel_id_;
   bool torque_;
+  int16_t right_velocity_limit_;
+  int16_t left_velocity_limit_;
 };
 
 #endif // TURTLEBOT3_MOTOR_DRIVER_H_


### PR DESCRIPTION
Fixes https://github.com/ROBOTIS-GIT/turtlebot3/issues/765. In short, commanded velocities were ignored for the turtlebot3 burger if they were higher than 0.22m/s.

This was because the constant `LIMIT_X_MAX_VELOCITY` was set specifically for the Dynamixel XM430-W210-T (i.e for the Turtlebot3 Waffle) but the Dynamixel XM430-W250-T (Burger) has a lower attainable velocity. Here, I set the constant to the lower value to match the Burger, but I read the max velocity for the constraint from the motor's control table itself so that the Waffle does not lose its higher wheel RPM.


